### PR TITLE
Fix for #8 renew/auto-apply button

### DIFF
--- a/src/Forms/Controls/Details/CertificateDetails.cs
+++ b/src/Forms/Controls/Details/CertificateDetails.cs
@@ -73,6 +73,8 @@ namespace Certify.Forms.Controls.Details
                 //update and create certificate
                 if (parentApp.VaultManager.RenewCertificate(item.IdentifierRef))
                 {
+					Populate(item); // update display with renewed info
+
                     MessageBox.Show("Renewal requested. Check certificate info for expiry. Auto Apply to update IIS certificate");
                 }
                 else

--- a/src/Forms/Controls/Details/CertificateDetails.cs
+++ b/src/Forms/Controls/Details/CertificateDetails.cs
@@ -73,7 +73,7 @@ namespace Certify.Forms.Controls.Details
                 //update and create certificate
                 if (parentApp.VaultManager.RenewCertificate(item.IdentifierRef))
                 {
-					Populate(item); // update display with renewed info
+                    Populate(item); // update display with renewed info
 
                     MessageBox.Show("Renewal requested. Check certificate info for expiry. Auto Apply to update IIS certificate");
                 }

--- a/src/Management/VaultManager.cs
+++ b/src/Management/VaultManager.cs
@@ -444,18 +444,13 @@ namespace Certify
             {
                 powershellManager.UpdateCertificate(certRef);
 
-                if (!CertExists(domainAlias))
+                if (CertExists(domainAlias)) // if the cert exists after the update, export it
                 {
                     var certInfo = GetCertificate(certRef);
-
                     string certId = "=" + certInfo.Id.ToString();
-                    //ExportCertificate(certId);
 
-                    if (!CertExists(domainAlias))
-                    {
-                        //if we have our first cert files, lets export the pfx as well
-                        ExportCertificate(certId, pfxOnly: true);
-                    }
+                    // if we have our first cert files, lets export the pfx as well
+                    ExportCertificate(certId, pfxOnly: true);
                 }
             }
             catch (Exception exp)


### PR DESCRIPTION
The "Renew" button on the Certificate Details control was not updating the UI after a successful renewal, and was not exporting the updated PFX on successful renewal, making it appear as though the "Auto Apply" function was not operational.

Before this change, Auto Apply would succeed if you click "Export" first (after a successful Renew). After this change, the Auto Apply button should work after a sucessful renew, and the UI is updated without having to click away and back to the certificate in the vault tree view.