### PR TITLE
Updated the Web.Config template to operate with more websites.

### DIFF
--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -138,15 +138,17 @@ namespace Certify.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;?xml version = &quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
-        /// &lt;configuration&gt;
-        ///     &lt;system.webServer&gt;
-        ///          &lt;staticContent&gt;
-        ///	        &lt;mimeMap fileExtension=&quot;.*&quot; mimeType=&quot;text/plain&quot; /&gt;
-        ///	        
-        ///   &lt;/staticContent&gt;
-        ///     &lt;/system.webServer&gt;
-        /// &lt;/configuration&gt;.
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+        ///
+        ///&lt;configuration&gt;
+        ///  &lt;system.webServer&gt;
+        ///    &lt;validation validateIntegratedModeConfiguration=&quot;false&quot; /&gt;
+        ///    &lt;staticContent&gt;
+        ///        &lt;mimeMap fileExtension=&quot;.&quot; mimeType=&quot;text/json&quot; /&gt;
+        ///    &lt;/staticContent&gt;
+        ///  &lt;handlers&gt;
+        ///      &lt;clear /&gt;
+        ///    &lt;add name=&quot;StaticFile&quot; path=&quot;*&quot; verb=&quot;*&quot; type=&quot;&quot; modules=&quot;StaticFileModule,DefaultDocumentModule,DirectoryListingModule&quot; scriptProcessor=&quot;&quot; resourceType=&quot;Either&quot; requireAccess=&quot;Read&quot; allowPathInfo=&quot;false&quot; preCondition=&quot;&quot; response [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string IISWebConfig {
             get {
@@ -155,14 +157,17 @@ namespace Certify.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;?xml version = &quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
-        /// &lt;configuration&gt;
-        ///     &lt;system.webServer&gt;
-        ///          &lt;staticContent&gt;
-        ///	        &lt;mimeMap fileExtension=&quot;.&quot; mimeType=&quot;text/plain&quot; /&gt;
-        ///   &lt;/staticContent&gt;
-        ///     &lt;/system.webServer&gt;
-        /// &lt;/configuration&gt;.
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+        ///
+        ///&lt;configuration&gt;
+        ///  &lt;system.webServer&gt;
+        ///    &lt;validation validateIntegratedModeConfiguration=&quot;false&quot; /&gt;
+        ///    &lt;staticContent&gt;
+        ///        &lt;mimeMap fileExtension=&quot;.&quot; mimeType=&quot;text/json&quot; /&gt;
+        ///    &lt;/staticContent&gt;
+        ///  &lt;handlers&gt;
+        ///      &lt;clear /&gt;
+        ///    &lt;add name=&quot;StaticFile&quot; path=&quot;*&quot; verb=&quot;*&quot; type=&quot;&quot; modules=&quot;StaticFileModule,DefaultDocumentModule,DirectoryListingModule&quot; scriptProcessor=&quot;&quot; resourceType=&quot;Either&quot; requireAccess=&quot;Read&quot; allowPathInfo=&quot;false&quot; preCondition=&quot;&quot; response [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string IISWebConfigAlt {
             get {

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -156,27 +156,48 @@ This software uses the following Open Source software (or significant portions o
     <value>Warning: This software is a pre-release version for testing and feedback purposes. You should expect bugs. Do not rely on this software for important production sites.</value>
   </data>
   <data name="IISWebConfig" xml:space="preserve">
-    <value>&lt;?xml version = "1.0" encoding="UTF-8"?&gt;
- &lt;configuration&gt;
-     &lt;system.webServer&gt;
-          &lt;staticContent&gt;
-	        &lt;mimeMap fileExtension=".*" mimeType="text/plain" /&gt;
-	        
-   &lt;/staticContent&gt;
-     &lt;/system.webServer&gt;
- &lt;/configuration&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+
+&lt;configuration&gt;
+  &lt;system.webServer&gt;
+    &lt;validation validateIntegratedModeConfiguration="false" /&gt;
+    &lt;staticContent&gt;
+        &lt;mimeMap fileExtension="." mimeType="text/json" /&gt;
+    &lt;/staticContent&gt;
+  &lt;handlers&gt;
+      &lt;clear /&gt;
+    &lt;add name="StaticFile" path="*" verb="*" type="" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" scriptProcessor="" resourceType="Either" requireAccess="Read" allowPathInfo="false" preCondition="" responseBufferLimit="4194304" /&gt;
+  &lt;/handlers&gt;
+  &lt;/system.webServer&gt;
+  &lt;system.web&gt;
+    &lt;authorization&gt;
+      &lt;allow users="*" /&gt;
+    &lt;/authorization&gt;
+  &lt;/system.web&gt;
+&lt;/configuration&gt;</value>
   </data>
   <data name="AIInstrumentationKey" xml:space="preserve">
     <value>63154103-66ba-4636-8c6b-7081084daa0e</value>
   </data>
   <data name="IISWebConfigAlt" xml:space="preserve">
-    <value>&lt;?xml version = "1.0" encoding="UTF-8"?&gt;
- &lt;configuration&gt;
-     &lt;system.webServer&gt;
-          &lt;staticContent&gt;
-	        &lt;mimeMap fileExtension="." mimeType="text/plain" /&gt;
-   &lt;/staticContent&gt;
-     &lt;/system.webServer&gt;
- &lt;/configuration&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+
+&lt;configuration&gt;
+  &lt;system.webServer&gt;
+    &lt;validation validateIntegratedModeConfiguration="false" /&gt;
+    &lt;staticContent&gt;
+        &lt;mimeMap fileExtension="." mimeType="text/json" /&gt;
+    &lt;/staticContent&gt;
+  &lt;handlers&gt;
+      &lt;clear /&gt;
+    &lt;add name="StaticFile" path="*" verb="*" type="" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" scriptProcessor="" resourceType="Either" requireAccess="Read" allowPathInfo="false" preCondition="" responseBufferLimit="4194304" /&gt;
+  &lt;/handlers&gt;
+  &lt;/system.webServer&gt;
+  &lt;system.web&gt;
+    &lt;authorization&gt;
+      &lt;allow users="*" /&gt;
+    &lt;/authorization&gt;
+  &lt;/system.web&gt;
+&lt;/configuration&gt;</value>
   </data>
 </root>


### PR DESCRIPTION
The web.config file that was used by default doesn't work with a lot of different sites because of the order of the extensionless URL handler and the Static file handler.  This update fixes the problem.