### PR TITLE
Ensure ACMESharp POSH module dependency is installed on startup

### DIFF
--- a/src/Forms/MainForm.cs
+++ b/src/Forms/MainForm.cs
@@ -572,13 +572,20 @@ namespace Certify
 
             if (!manager.IsValidVersion())
             {
- 
                 if (MessageBox.Show("The version of Powershell installed is not high enough, please install Powershell Version 3 or higher.", "Powershell Version Too Low", MessageBoxButtons.OK, MessageBoxIcon.Error) == DialogResult.OK)
                 {
                     Application.Exit();
                 }
             }
 
+            if (!manager.IsAcmeSharpModuleInstalled())
+            {
+                if (MessageBox.Show("The required PowerShell module 'ACMESharp' cannot be found.",
+                        "ACMESharp Missing", MessageBoxButtons.OK, MessageBoxIcon.Error) == DialogResult.OK)
+                {
+                    Application.Exit();
+                }
+            }
         }
     }
 }

--- a/src/Management/PowershellManager.cs
+++ b/src/Management/PowershellManager.cs
@@ -56,6 +56,21 @@ namespace Certify
             return !version.Equals(1) && !version.Equals(2) && !version.Equals(0);
         }
 
+        public bool IsAcmeSharpModuleInstalled()
+        {
+            ps.Commands.Clear();
+            var cmd = ps.Commands.AddCommand("Get-Module");
+            cmd.AddParameter("ListAvailable");
+            cmd.AddArgument("ACMESharp");
+
+            LogAction("Powershell: Get-Module -ListAvailable ACMESharp");
+
+            var res = InvokeCurrentPSCommand();
+
+            return res.IsOK && (res.Result as
+                    System.Collections.IEnumerable)?.OfType<object>().Count() > 0;
+        }
+
         private void LogAction(string command, string result = null)
         {
             if (this.ActionLogs != null)


### PR DESCRIPTION
Was getting weird behavior when I tested this out in an environment that didn't have ACMESharp POSH module installed, but couldn't understand it -- it was because the POSH module wasn't installed.

This adds a test during app startup to make sure that it's there before continuing.
