### PR TITLE
Add support for International domain names

### DIFF
--- a/src/Certify.Windows.csproj
+++ b/src/Certify.Windows.csproj
@@ -129,7 +129,10 @@
       <HintPath>..\packages\Microsoft.ApplicationInsights.1.2.3\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/src/Management/IISManager.cs
+++ b/src/Management/IISManager.cs
@@ -4,8 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading.Tasks;
 using Certify.Models;
 
 namespace Certify.Management
@@ -16,7 +14,7 @@ namespace Certify.Management
 
     public class IISManager
     {
-        #region IIS 
+        #region IIS
 
         private readonly bool _showOnlyStartedWebsites = Properties.Settings.Default.ShowOnlyStartedWebsites;
 
@@ -173,7 +171,6 @@ namespace Certify.Management
                             }
                             catch (Exception)
                             {
-                                ; ;
                                 System.Diagnostics.Debug.WriteLine("Cannot apply SNI SSL Flag");
                             }
                         }

--- a/src/Management/PowershellManager.cs
+++ b/src/Management/PowershellManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
@@ -15,6 +16,8 @@ namespace Certify
     {
         private PowerShell ps = null;
         private List<ActionLogItem> ActionLogs = null;
+
+        private readonly IdnMapping _idnMapping = new IdnMapping();
 
         public PowershellManager(string workingDirectory, List<ActionLogItem> actionLogs)
         {
@@ -158,6 +161,9 @@ namespace Certify
         public APIResult NewIdentifier(string dns, string alias, string label)
         {
             ps.Commands.Clear();
+
+            // ACME service requires international domain names in ascii mode
+            dns = _idnMapping.GetAscii(dns);
 
             var cmd = ps.Commands.AddCommand("New-ACMEIdentifier");
             cmd.AddParameter("Dns", dns);

--- a/src/Management/PowershellManager.cs
+++ b/src/Management/PowershellManager.cs
@@ -1,14 +1,12 @@
-﻿using ACMESharp.Vault.Model;
-using ACMESharp.Vault.Providers;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
-using System.Text;
-using System.Threading.Tasks;
 using ACMESharp;
+using ACMESharp.Vault.Model;
+using ACMESharp.Vault.Providers;
 using Certify.Models;
 
 namespace Certify
@@ -85,7 +83,7 @@ namespace Certify
             ps.Runspace.SessionStateProxy.Path.SetLocation(path);
         }
 
-        #region API 
+        #region API
 
         private APIResult InvokeCurrentPSCommand()
         {
@@ -210,7 +208,7 @@ namespace Certify
             return null;
         }
 
-        public APIResult CompleteChallenge(string identifierRef, string challengeType = "http-01",  bool regenerate = true)
+        public APIResult CompleteChallenge(string identifierRef, string challengeType = "http-01", bool regenerate = true)
         {
             ps.Commands.Clear();
 
@@ -247,7 +245,7 @@ namespace Certify
             return InvokeCurrentPSCommand();
         }
 
-        public APIResult NewCertificate(string identifierRef, string certAlias, string[] subjectAlternativeNames =null)
+        public APIResult NewCertificate(string identifierRef, string certAlias, string[] subjectAlternativeNames = null)
         {
             ps.Commands.Clear();
 
@@ -256,15 +254,15 @@ namespace Certify
             cmd.AddParameter("Alias", certAlias);
 
             string sanList = null;
-            if (subjectAlternativeNames!=null && subjectAlternativeNames.Length > 0)
+            if (subjectAlternativeNames != null && subjectAlternativeNames.Length > 0)
             {
                 sanList = string.Join(",", subjectAlternativeNames);
                 cmd.AddParameter("AlternativeIdentifierRefs", sanList);
-               
+
             }
             cmd.AddParameter("Generate");
 
-            LogAction("Powershell: New-ACMECertificate -Identifier " + identifierRef + " -Alias " + certAlias + " -Generate"+ (sanList!=null? " -AlternativeIdentifierRefs "+sanList:""));
+            LogAction("Powershell: New-ACMECertificate -Identifier " + identifierRef + " -Alias " + certAlias + " -Generate" + (sanList != null ? " -AlternativeIdentifierRefs " + sanList : ""));
 
             return InvokeCurrentPSCommand();
         }
@@ -298,7 +296,6 @@ namespace Certify
 
         public APIResult ExportCertificate(string certAlias, string vaultFolderPath, bool pfxOnly = false)
         {
-            
             string certKey = certAlias;
             if (certKey.StartsWith("=")) certKey = certKey.Replace("=", "");
             ps.Commands.Clear();
@@ -307,7 +304,7 @@ namespace Certify
             cmd.AddParameter("Ref", certAlias);
             if (!pfxOnly)
             {
-                cmd.AddParameter("ExportKeyPEM", vaultFolderPath + "\\"+ LocalDiskVault.KEYPM + "\\" + certKey + "-key.pem");
+                cmd.AddParameter("ExportKeyPEM", vaultFolderPath + "\\" + LocalDiskVault.KEYPM + "\\" + certKey + "-key.pem");
                 cmd.AddParameter("ExportCsrPEM", vaultFolderPath + "\\" + LocalDiskVault.CSRPM + "\\" + certKey + "-csr.pem");
                 cmd.AddParameter("ExportCertificatePEM", vaultFolderPath + "\\" + LocalDiskVault.CRTPM + "\\" + certKey + "-crt.pem");
                 cmd.AddParameter("ExportCertificateDER", vaultFolderPath + "\\" + LocalDiskVault.CRTDR + "\\" + certKey + "-crt.der");

--- a/src/packages.config
+++ b/src/packages.config
@@ -12,6 +12,7 @@
   <package id="ManagedOpenSsl32" version="0.6.1.3" targetFramework="net45" />
   <package id="ManagedOpenSsl64" version="0.6.1.3" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights" version="1.2.3" targetFramework="net45" />
+  <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I have a personal project with international domain name and I wanted to install LetsEncrypt cert on it using Certify.

The changes boiled down to two modifications (International Domain Name bindings in IIS are configured with non-ascii chars)
1. Certificate dns should be requested in ASCII
2. When installing certificate into IIS the bindings should be searched using Unicode variant of domain name

Successfully installed certificates on these domains:
https://grojaraštis.lt/ https://www.grojaraštis.lt/

![image](https://cloud.githubusercontent.com/assets/483659/20769562/355e4960-b74b-11e6-8441-9642873c3165.png)
