### PR TITLE
Fixed bug preventing cert deletion

### DIFF
--- a/src/Management/IISManager.cs
+++ b/src/Management/IISManager.cs
@@ -133,7 +133,7 @@ namespace Certify.Management
             {
                 try
                 {
-                    store.Certificates.Remove(oldCert);
+                    store.Remove(oldCert);
                 }
                 catch (Exception exp)
                 {


### PR DESCRIPTION
Previous method was only removing the certificate from a certificate collection. The cert will now be removed from the store.