### PR TITLE
Prevent alias from beginning with a digit, fix bug causing null reference exception

### DIFF
--- a/src/Certify.Core/Management/VaultManager.cs
+++ b/src/Certify.Core/Management/VaultManager.cs
@@ -486,9 +486,8 @@ namespace Certify
                 var result = powershellManager.NewIdentifier(domain, identifierAlias, "Identifier:" + domain);
                 if (!result.IsOK) return null;
             }
-            ReloadVaultConfig();
 
-            var identifier = this.GetIdentifier(identifierAlias);
+            var identifier = this.GetIdentifier(identifierAlias, reloadVaultConfig: true);
 
             /*
             //config file now has a temp path to write to, begin challenge (writes to temp file with challenge content)
@@ -571,6 +570,14 @@ namespace Certify
         {
             var domainAlias = domain.Replace(".", "_");
             domainAlias += long.Parse(DateTime.UtcNow.ToString("yyyyMMddHHmmss"));
+
+            // Check if the first character in the domain is a digit, e.g. 1and1.com
+            // Per ACMESharp spec, alias cannot begin with a digit.
+            if (char.IsDigit(domainAlias[0]))
+            {
+                domainAlias = "alias_" + domainAlias;
+            }
+
             return domainAlias;
         }
 

--- a/src/Certify.Core/Management/VaultManager.cs
+++ b/src/Certify.Core/Management/VaultManager.cs
@@ -329,18 +329,22 @@ namespace Certify
                 try
                 {
                     vlt.OpenStorage(true);
-                    var idsToRemove = vaultConfig.Identifiers.Values.Where(i => i.Dns == dns);
-                    List<Guid> removing = new List<Guid>();
-                    foreach (var identifier in idsToRemove)
+                    if (vaultConfig.Identifiers != null)
                     {
-                        removing.Add(identifier.Id);
-                    }
-                    foreach (var identifier in removing)
-                    {
-                        vaultConfig.Identifiers.Remove(identifier);
+                        var idsToRemove = vaultConfig.Identifiers.Values.Where(i => i.Dns == dns);
+                        List<Guid> removing = new List<Guid>();
+                        foreach (var identifier in idsToRemove)
+                        {
+                            removing.Add(identifier.Id);
+                        }
+                        foreach (var identifier in removing)
+                        {
+                            vaultConfig.Identifiers.Remove(identifier);
+                        }
+
+                        vlt.SaveVault(vaultConfig);
                     }
 
-                    vlt.SaveVault(vaultConfig);
                     return true;
                 }
                 catch (Exception e)

--- a/src/Certify.Winforms/Forms/Controls/CertRequestSettingsIIS.cs
+++ b/src/Certify.Winforms/Forms/Controls/CertRequestSettingsIIS.cs
@@ -140,6 +140,7 @@ namespace Certify.Forms.Controls
                     if (!chkSkipConfigCheck.Checked && !authorization.ExtensionlessConfigCheckedOK)
                     {
                         MessageBox.Show("Automated checks for extensionless content failed. Authorisations will not be able to complete. Change the web.config in <your site>\\.well-known\\acme-challenge and ensure you can browse to http://<your site>/.well-known/acme-challenge/configcheck before proceeding.");
+                        CloseParentForm();
                         return;
                     }
                     //at this point we can either get the user to manually copy the file to web site folder structure


### PR DESCRIPTION
Updated the ComputeIdentifierAlias method to check if the domain begins with a digit. If so, it will prepend the string "alias_" so that it is compliant with the ACMESharp specs. See webprofusion/Certify#38.

Fixed bug that caused a null reference exception if you call DeleteIdentifierByDNS after the vault is first initialized.

Fixed bug where CertRequestDialog wasn't closing after checks for extensionless content fail.