### PR TITLE
Fix support for international domain names

### DIFF
--- a/src/Certify.CLI/Certify.CLI.csproj
+++ b/src/Certify.CLI/Certify.CLI.csproj
@@ -36,7 +36,10 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+    <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/src/Certify.CLI/Program.cs
+++ b/src/Certify.CLI/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -29,6 +30,8 @@ namespace Certify.CLI
 
             return 0;
         }
+
+        private readonly IdnMapping _idnMapping = new IdnMapping();
 
         private void PerformVaultCleanup()
         {
@@ -91,6 +94,9 @@ namespace Certify.CLI
 
         private bool PerformCertRequestAndIISBinding(string certDomain)
         {
+            // ACME service requires international domain names in ascii mode
+            certDomain = _idnMapping.GetAscii(certDomain);
+
             //create cert and binding it
 
             //Typical command sequence for a new certificate

--- a/src/Certify.CLI/packages.config
+++ b/src/Certify.CLI/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/src/Certify.Core/Certify.Core.csproj
+++ b/src/Certify.Core/Certify.Core.csproj
@@ -86,7 +86,10 @@
       <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/src/Certify.Core/Management/IISManager.cs
+++ b/src/Certify.Core/Management/IISManager.cs
@@ -100,8 +100,7 @@ namespace Certify.Management
 
         public Site GetSiteByDomain(string domain)
         {
-            //domain = _idnMapping.GetUnicode(domain);
-            var asciiDomain = _idnMapping.GetAscii(domain);
+            domain = _idnMapping.GetUnicode(domain);
             using (var iisManager = new ServerManager())
             {
                 var sites = GetSites(iisManager, false).ToList();
@@ -121,6 +120,8 @@ namespace Certify.Management
 
         public SiteBindingItem GetSiteBindingByDomain(string domain)
         {
+            domain = _idnMapping.GetUnicode(domain);
+
             var site = GetSiteByDomain(domain);
             if (site != null)
             {

--- a/src/Certify.Core/Management/PowershellManager.cs
+++ b/src/Certify.Core/Management/PowershellManager.cs
@@ -3,7 +3,6 @@ using ACMESharp.Vault.Providers;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
@@ -18,8 +17,6 @@ namespace Certify
     {
         private PowerShell ps = null;
         private List<ActionLogItem> ActionLogs = null;
-
-        private readonly IdnMapping _idnMapping = new IdnMapping();
 
         public PowershellManager(string workingDirectory, List<ActionLogItem> actionLogs)
         {
@@ -80,7 +77,8 @@ namespace Certify
                     powershellVersion = int.Parse(ver[0]);
                 }
                 return powershellVersion;
-            } catch( Exception exp)
+            }
+            catch (Exception exp)
             {
                 System.Diagnostics.Debug.WriteLine(exp.ToString());
                 return 0;
@@ -118,7 +116,7 @@ namespace Certify
 
         #region API
 
-        private APIResult InvokeCurrentPSCommand(bool discardErrors=false)
+        private APIResult InvokeCurrentPSCommand(bool discardErrors = false)
         {
             try
             {
@@ -156,7 +154,7 @@ namespace Certify
 
             LogAction("Powershell: Initialize-ACMEVault -BaseURI " + baseURI);
 
-            return InvokeCurrentPSCommand(discardErrors:true);
+            return InvokeCurrentPSCommand(discardErrors: true);
         }
 
         public APIResult NewRegistration(string contacts)
@@ -196,9 +194,6 @@ namespace Certify
         public APIResult NewIdentifier(string dns, string alias, string label)
         {
             ps.Commands.Clear();
-
-            // ACME service requires international domain names in ascii mode
-            dns = _idnMapping.GetAscii(dns);
 
             var cmd = ps.Commands.AddCommand("New-ACMEIdentifier");
             cmd.AddParameter("Dns", dns);

--- a/src/Certify.Core/packages.config
+++ b/src/Certify.Core/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net45" />
 </packages>

--- a/src/Certify.Winforms/Certify.Winforms.csproj
+++ b/src/Certify.Winforms/Certify.Winforms.csproj
@@ -85,7 +85,10 @@
       <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management" />

--- a/src/Certify.Winforms/Forms/Controls/CertRequestSettingsIIS.cs
+++ b/src/Certify.Winforms/Forms/Controls/CertRequestSettingsIIS.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using ACMESharp.Vault.Providers;
 using Certify.Management;
@@ -17,6 +12,8 @@ namespace Certify.Forms.Controls
 {
     public partial class CertRequestSettingsIIS : CertRequestBaseControl
     {
+        private readonly IdnMapping _idnMapping = new IdnMapping();
+
         public CertRequestSettingsIIS()
         {
             InitializeComponent();
@@ -85,7 +82,7 @@ namespace Certify.Forms.Controls
 
             CertRequestConfig config = new CertRequestConfig();
             var selectItem = (SiteBindingItem)lstSites.SelectedItem;
-            config.Domain = selectItem.Host;
+            config.Domain = _idnMapping.GetAscii(selectItem.Host); // ACME service requires international domain names in ascii mode
             config.PerformChallengeFileCopy = true;
             config.PerformExtensionlessConfigChecks = !chkSkipConfigCheck.Checked;
             config.PerformExtensionlessAutoConfig = true;

--- a/src/Certify.Winforms/packages.config
+++ b/src/Certify.Winforms/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
So almost three months have passed since I submitted PR for IDNs and I had to renew certs but had to make some fixes for Certify to work.

Main theme of the changes is that when dealing with ACMESharp we should always use ASCII representation of IDN but when dealing with IIS we should use pretty (unicode) name.