### PR TITLE
Workaround for Microsoft RSA SChannel Cryptographic Provider Support 

### DIFF
--- a/src/Certify.CLI/Certify.CLI.csproj
+++ b/src/Certify.CLI/Certify.CLI.csproj
@@ -41,13 +41,15 @@
     </Reference>
     <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Certify.CLI/packages.config
+++ b/src/Certify.CLI/packages.config
@@ -3,4 +3,5 @@
   <package id="Microsoft.ApplicationInsights" version="2.3.0" targetFramework="net45" />
   <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/Certify.Core/Management/CertificateManager.cs
+++ b/src/Certify.Core/Management/CertificateManager.cs
@@ -45,7 +45,7 @@ namespace Certify.Management
             // The certificate should be registered using this legacy method on the machine to support Exchage Server.
 
             int exitCode = 0;
-            string certExportPath = Environment.SpecialFolder.ApplicationData + "\\CertifyCertificateLegacyTemp.pfx";
+            string certExportPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\CertifyCertificateLegacyTemp.pfx";
             try {
                 if (System.IO.File.Exists(certExportPath)) {
                     System.IO.File.Delete(certExportPath);

--- a/src/Certify.Core/Properties/Settings.Designer.cs
+++ b/src/Certify.Core/Properties/Settings.Designer.cs
@@ -139,5 +139,17 @@ namespace Certify.Properties {
                 this["RenewalIntervalDays"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LegacyRSASChannelSupport {
+            get {
+                return ((bool)(this["LegacyRSASChannelSupport"]));
+            }
+            set {
+                this["LegacyRSASChannelSupport"] = value;
+            }
+        }
     }
 }

--- a/src/Certify.Core/Properties/Settings.settings
+++ b/src/Certify.Core/Properties/Settings.settings
@@ -32,5 +32,8 @@
     <Setting Name="RenewalIntervalDays" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">14</Value>
     </Setting>
+    <Setting Name="LegacyRSASChannelSupport" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/Certify.UI/Controls/Settings.xaml
+++ b/src/Certify.UI/Controls/Settings.xaml
@@ -29,6 +29,7 @@
             <CheckBox x:Name="EnableProxyAPICheckbox" Content="Enable proxy API for domain config checks" Unchecked="SettingsUpdated" Checked="SettingsUpdated" Margin="0,4,0,0" />
             <CheckBox x:Name="EnableEFS" Content="Enable Encrypted File System (EFS) for sensitive files. This option does not work on all versions of Windows." Unchecked="SettingsUpdated" Checked="SettingsUpdated" Margin="0,4,0,0" />
             <CheckBox x:Name="IgnoreStoppedSites" Content="Ignore stopped IIS sites for new certificates and renewals" Unchecked="SettingsUpdated" Checked="SettingsUpdated" Margin="0,4,0,0" />
+            <CheckBox x:Name="UseLegacyImportForExchange" Content="Use Legacy Microsoft RSA SChannel Cryptographic Provider for Exchange" Unchecked="SettingsUpdated" Checked="SettingsUpdated" Margin="0,4,0,0" />
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/src/Certify.UI/Controls/Settings.xaml.cs
+++ b/src/Certify.UI/Controls/Settings.xaml.cs
@@ -39,6 +39,7 @@ namespace Certify.UI.Controls
             this.CheckForUpdatesCheckbox.IsChecked = Certify.Properties.Settings.Default.CheckForUpdatesAtStartup;
             this.EnableTelematicsCheckbox.IsChecked = Certify.Properties.Settings.Default.EnableAppTelematics;
             this.EnableProxyAPICheckbox.IsChecked = Certify.Properties.Settings.Default.EnableValidationProxyAPI;
+            this.UseLegacyImportForExchange.IsChecked = Certify.Properties.Settings.Default.LegacyRSASChannelSupport;
 
             //if true, EFS will be used for sensitive files such as private key file, does not work in all versions of windows.
             this.EnableEFS.IsChecked = Certify.Properties.Settings.Default.EnableEFS;
@@ -68,6 +69,7 @@ namespace Certify.UI.Controls
                 Certify.Properties.Settings.Default.CheckForUpdatesAtStartup = (this.CheckForUpdatesCheckbox.IsChecked == true);
                 Certify.Properties.Settings.Default.EnableAppTelematics = (this.EnableTelematicsCheckbox.IsChecked == true);
                 Certify.Properties.Settings.Default.EnableValidationProxyAPI = (this.EnableProxyAPICheckbox.IsChecked == true);
+                Certify.Properties.Settings.Default.LegacyRSASChannelSupport = (this.UseLegacyImportForExchange.IsChecked == true);
 
                 Certify.Properties.Settings.Default.EnableEFS = (this.EnableEFS.IsChecked == true);
                 Certify.Properties.Settings.Default.IgnoreStoppedSites = (this.IgnoreStoppedSites.IsChecked == true);


### PR DESCRIPTION
Workaround for issue #112. Adds a checkbox in the settings screen (off by default) which forces certificates to be exported and reimported to the local computer using the Microsoft RSA SChannel Cryptographic Provider. This allows the certificate to be used with Microsoft Exchange.

Without using the Microsoft RSA SChannel Cryptographic Provider, redirect loops are seen when using the Outlook Web Application to access emails.
https://blogs.technet.microsoft.com/jasonsla/2015/01/15/the-one-with-the-fba-redirect-loop/

This is my first ever pull request. I can't see a way to specify the Microsoft RSA SChannel Cryptographic Provider, hence I fell back to using the command line tool: certutil to export, delete and then re-import the certificate to enable this legacy support.