### PR TITLE
Improved support for IIS7.5 (Server 2008 R2)

### DIFF
--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml
@@ -131,7 +131,7 @@
                             <TextBox Text="{Binding SelectedItem.RequestConfig.BindingPort}" Width="225" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <Label Width="131" Content="Use SNI (Server 2012 onwards):" />
+                            <Label Width="131" Content="Use SNI (IIS 8+):" />
                             <CheckBox IsChecked="{Binding SelectedItem.RequestConfig.BindingUseSNI}"></CheckBox>
                         </StackPanel>
                     </StackPanel>

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -50,6 +50,13 @@ namespace Certify.UI.Controls
                     MessageBox.Show("A Primary Domain must be selected");
                     return;
                 }
+
+                if (MainViewModel.SelectedItem.RequestConfig.PerformAutomatedCertBinding)
+                {
+                    MainViewModel.SelectedItem.RequestConfig.BindingIPAddress = null;
+                    MainViewModel.SelectedItem.RequestConfig.BindingPort = null;
+                    MainViewModel.SelectedItem.RequestConfig.BindingUseSNI = null;
+                }
                 //save changes
 
                 //creating new managed item

--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -28,7 +28,7 @@
                     <StackPanel Orientation="Vertical" Margin="0,8,0,0">
                         <StackPanel Orientation="Horizontal">
                             <fa:FontAwesome Icon="Globe" Margin="0,0,8,0" />
-                            <TextBlock Text="{Binding Name}" FontWeight="Bold" Margin="0,0,8,0" Foreground="{DynamicResource {x:Static SystemColors.ActiveCaptionTextBrushKey} }" />
+                            <TextBlock Text="{Binding Name}" FontWeight="Bold" Margin="0,0,8,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrush} }" />
                         </StackPanel>
 
                         <TextBlock Text="{Binding Path=ItemType, Converter={StaticResource EnumConverter}}" Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" Margin="16,0,0,0" FontSize="10" />


### PR DESCRIPTION
The cert auto-install wasn't working right in IIS7.5, it would create HTTPS bindings including the hostname which isn't supported (SNI is also not available). Changed the default behavior to auto create host- and sni-less bindings for IIS versions below 8.

A few small UI changes - the managed site title was white-on-white on Server 2008 R2's default color scheme, fixed that, and shortened some label text which was being overlapped by a checkbox.

Also cleared out the manual binding info being saved to `manageditems.json` if the user changed from manual back to auto-binding and saved, to avoid those values being used by `IISManager.InstallCertForRequest`.