### PR TITLE
Add Powershell Hooks for Pre/Post Request Actions

### DIFF
--- a/src/Certify.Core/Certify.Core.csproj
+++ b/src/Certify.Core/Certify.Core.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Management\ItemManager.cs" />
     <Compile Include="Management\IVaultProvider.cs" />
     <Compile Include="Management\PluginManager.cs" />
+    <Compile Include="Management\PowerShellManager.cs" />
     <Compile Include="Management\SecurityProtocolsManager.cs" />
     <Compile Include="Models\ActionLogItem.cs" />
     <Compile Include="Models\APIResponses.cs" />

--- a/src/Certify.Core/Management/PowerShellManager.cs
+++ b/src/Certify.Core/Management/PowerShellManager.cs
@@ -1,0 +1,99 @@
+﻿using Certify.Models;
+using System;
+using System.IO;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Certify.Management
+{
+    public class PowerShellManager
+    {
+        public static async Task<string> RunScript(CertificateRequestResult result, string scriptFile)
+        {
+            // argument check for script file existance and .ps1 extension
+            var scriptInfo = new FileInfo(scriptFile);
+            if (!scriptInfo.Exists)
+            {
+                throw new ArgumentException($"File '{scriptFile}' does not exist.");
+            }
+            if (scriptInfo.Extension != ".ps1")
+            {
+                throw new ArgumentException($"File '{scriptFile}' is not a powershell script.");
+            }
+
+            try
+            {
+                // create a new runspace to isolate the scripts
+                using (var runspace = RunspaceFactory.CreateRunspace())
+                {
+                    runspace.Open();
+                    
+                    // set working directory to the script file's directory 
+                    runspace.SessionStateProxy.Path.SetLocation(scriptInfo.DirectoryName);
+
+                    using (PowerShell shell = PowerShell.Create())
+                    {
+                        shell.Runspace = runspace;
+
+                        // ensure execution policy will allow the script to run
+                        shell.AddCommand("Set-ExecutionPolicy")
+                                .AddParameter("ExecutionPolicy", "Unrestricted")
+                                .AddParameter("Scope", "Process")
+                                .AddParameter("Force")
+                                .Invoke();
+
+                        // add script command to invoke
+                        shell.AddCommand(scriptFile);
+
+                        // pass the result to the script
+                        shell.AddParameter("result", result);
+
+                        // accumulate output
+                        var output = new StringBuilder();
+
+                        // capture errors
+                        shell.Streams.Error.DataAdded += (sender, args) =>
+                        {
+                            var error = shell.Streams.Error[args.Index];
+                            string src = error.InvocationInfo.MyCommand?.ToString() ?? error.InvocationInfo.InvocationName;
+                            output.AppendLine($"{src}: {error}\n{error.InvocationInfo.PositionMessage}");
+                        };
+                        // capture write-* methods (except write-host)
+                        shell.Streams.Warning.DataAdded += (sender, args) => output.AppendLine(shell.Streams.Warning[args.Index].Message);
+                        shell.Streams.Debug.DataAdded += (sender, args) => output.AppendLine(shell.Streams.Debug[args.Index].Message);
+                        shell.Streams.Verbose.DataAdded += (sender, args) => output.AppendLine(shell.Streams.Verbose[args.Index].Message);
+
+                        var outputData = new PSDataCollection<PSObject>();
+                        outputData.DataAdded += (sender, args) =>
+                        {
+                            // capture all main output
+                            object data = outputData[args.Index]?.BaseObject;
+                            if (data != null) output.AppendLine(data.ToString());
+                        };
+                        await Task.Run(() =>
+                        {
+                            try
+                            {
+                                var async = shell.BeginInvoke<PSObject, PSObject>(null, outputData);
+                                shell.EndInvoke(async);
+                            }
+                            catch (ParseException ex)
+                            {
+                                // this should only happen in case of script syntax errors, otherwise
+                                // errors would be output via the invoke's error stream 
+                                output.AppendLine($"{ex.Message}");
+                            }
+                        });
+                        return output.ToString().TrimEnd('\n');
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                return $"Error - {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}";
+            }
+        }
+    }
+}

--- a/src/Certify.Core/Models/CertRequestConfig.cs
+++ b/src/Certify.Core/Models/CertRequestConfig.cs
@@ -74,5 +74,15 @@ namespace Certify.Models
         /// In the case of Lets Encrypt, the challenge type this request will use (eg. http-01)
         /// </summary>
         public string ChallengeType { get; set; }
+
+        /// <summary>
+        /// PowerShell script to run before executing certificate request
+        /// </summary>
+        public string PreRequestPowerShellScript { get; set; }
+
+        /// <summary>
+        /// PowerShell script to run before executing certificate request
+        /// </summary>
+        public string PostRequestPowerShellScript { get; set; }
     }
 }

--- a/src/Certify.Core/Models/CertificateRequestResult.cs
+++ b/src/Certify.Core/Models/CertificateRequestResult.cs
@@ -10,6 +10,7 @@ namespace Certify.Models
     {
         public ManagedItem ManagedItem { get; set; }
         public bool IsSuccess { get; set; }
+        public bool Abort { get; set; }
         public string Message { get; set; }
         public object Result { get; set; }
     }

--- a/src/Certify.UI/Certify.UI.csproj
+++ b/src/Certify.UI/Certify.UI.csproj
@@ -90,6 +90,7 @@
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MahApps.Metro.1.5.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
     </Reference>

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml
@@ -61,94 +61,120 @@
         <dragablz:TabablzControl x:Name="SettingsTab" Margin="8" Grid.Row="2" VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch">
 
             <TabItem Header="Options" IsSelected="True">
+				<ScrollViewer VerticalScrollBarVisibility="Auto">
+					<StackPanel Margin="0,16,0,0">
+						<StackPanel Orientation="Horizontal" Visibility="{Binding IsWebsiteSelectable, Converter={StaticResource ResourceKey=BoolToVisConverter}}">
+							<Label Width="136" Content="Select IIS Site:" />
+							<ComboBox ItemsSource="{Binding WebSiteList}" SelectedItem="{Binding SelectedWebSite}"  DisplayMemberPath="SiteName" Width="225" SelectionChanged="Website_SelectionChanged" />
+						</StackPanel>
+						<StackPanel Orientation="Vertical" Visibility="{Binding SelectedItem, Converter={StaticResource ResourceKey=NullVisConverter}}">
+							<StackPanel Orientation="Horizontal">
+								<Label Width="136" Content="Display Name:" />
+								<TextBox Text="{Binding SelectedItem.Name, UpdateSourceTrigger=PropertyChanged}" Width="225" />
+							</StackPanel>
+							<StackPanel Orientation="Vertical" Margin="136,8,0,0">
+								<CheckBox Content="Enable Auto Renewal" IsChecked="{Binding SelectedItem.IncludeInAutoRenew}" />
+								<CheckBox Content="Notify Primary Contact On Renewal Failure" IsChecked="{Binding SelectedItem.RequestConfig.EnableFailureNotifications}" />
+							</StackPanel>
+							<StackPanel x:Name="NoBindings" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=InvBoolVisConverter}}" Orientation="Vertical"  Margin="0,8,0,0">
+								<TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="16,0" FontWeight="Bold" FontFamily="Segoe UI Semibold" Foreground="#FFEA1010"><Run Text="There are no http or https hostname bindings associated with the selected site in IIS. At least one fully qualified hostname (e.g 'github.com') is required to create a certificate." /></TextBlock>
+							</StackPanel>
+							<StackPanel x:Name="DomainOptions" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=BoolToVisConverter}}" Orientation="Vertical" Background="#FFF7F7F7" Margin="0,8,0,0">
+								<StackPanel Orientation="Vertical" Margin="0,16,0,16" HorizontalAlignment="Left">
+									<TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="8,0,0,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" FontWeight="Bold" FontFamily="Segoe UI Semibold"><Run Text="The following selected domains will be included as a single certificate request. The Lets Encrypt service must be able to access all of theses domains via HTTP (port 80) for the certification process to work." /></TextBlock>
+								</StackPanel>
 
-                <StackPanel Margin="0,16,0,0">
-                    <StackPanel Orientation="Horizontal" Visibility="{Binding IsWebsiteSelectable, Converter={StaticResource ResourceKey=BoolToVisConverter}}">
-                        <Label Width="136" Content="Select IIS Site:" />
-                        <ComboBox ItemsSource="{Binding WebSiteList}" SelectedItem="{Binding SelectedWebSite}"  DisplayMemberPath="SiteName" Width="225" SelectionChanged="Website_SelectionChanged" />
-                    </StackPanel>
-                    <StackPanel Orientation="Vertical" Visibility="{Binding SelectedItem, Converter={StaticResource ResourceKey=NullVisConverter}}">
-                        <StackPanel Orientation="Horizontal">
-                            <Label Width="136" Content="Display Name:" />
-                            <TextBox Text="{Binding SelectedItem.Name, UpdateSourceTrigger=PropertyChanged}" Width="225" />
-                        </StackPanel>
-                        <StackPanel Orientation="Vertical" Margin="136,8,0,0">
-                            <CheckBox Content="Enable Auto Renewal" IsChecked="{Binding SelectedItem.IncludeInAutoRenew}" />
-                            <CheckBox Content="Notify Primary Contact On Renewal Failure" IsChecked="{Binding SelectedItem.RequestConfig.EnableFailureNotifications}" />
-                        </StackPanel>
-                        <StackPanel x:Name="NoBindings" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=InvBoolVisConverter}}" Orientation="Vertical"  Margin="0,8,0,0">
-                            <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="16,0" FontWeight="Bold" FontFamily="Segoe UI Semibold" Foreground="#FFEA1010"><Run Text="There are no http or https hostname bindings associated with the selected site in IIS. At least one fully qualified hostname (e.g 'github.com') is required to create a certificate." /></TextBlock>
-                        </StackPanel>
-                        <StackPanel x:Name="DomainOptions" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=BoolToVisConverter}}" Orientation="Vertical" Background="#FFF7F7F7" Margin="0,8,0,0">
-                            <StackPanel Orientation="Vertical" Margin="0,16,0,16" HorizontalAlignment="Left">
-                                <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="8,0,0,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" FontWeight="Bold" FontFamily="Segoe UI Semibold"><Run Text="The following selected domains will be included as a single certificate request. The Lets Encrypt service must be able to access all of theses domains via HTTP (port 80) for the certification process to work." /></TextBlock>
-                            </StackPanel>
+								<StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+									<Label Content="Domains and Subdomains to include:" />
+									<Button Content="Select All" Command="{Binding SANSelectAllCommand}" Margin="16,0,0,0" />
+									<Button Content="Select None" Command="{Binding SANSelectNoneCommand}" Margin="8,0,0,0" />
+								</StackPanel>
+								<StackPanel Orientation="Vertical">
 
-                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                <Label Content="Domains and Subdomains to include:" />
-                                <Button Content="Select All" Command="{Binding SANSelectAllCommand}" Margin="16,0,0,0" />
-                                <Button Content="Select None" Command="{Binding SANSelectNoneCommand}" Margin="8,0,0,0" />
-                            </StackPanel>
-                            <StackPanel Orientation="Vertical">
+									<DataGrid AutoGenerateColumns="False" CanUserAddRows="False" VerticalScrollBarVisibility="Auto" Height="180" ItemsSource="{Binding SelectedItem.DomainOptions}">
+										<DataGrid.Columns>
 
-                                <DataGrid AutoGenerateColumns="False" CanUserAddRows="False" VerticalScrollBarVisibility="Auto" Height="180" ItemsSource="{Binding SelectedItem.DomainOptions}">
-                                    <DataGrid.Columns>
-
-                                        <DataGridCheckBoxColumn Header="Include" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" />
-                                        <DataGridTextColumn Header="Domain" Binding="{Binding Domain, UpdateSourceTrigger=PropertyChanged}" Width="400" IsReadOnly="True" />
-                                        <DataGridTemplateColumn Header="Primary">
-                                            <DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate>
-                                                    <RadioButton GroupName="PrimaryDomainGroup" IsChecked="{Binding IsPrimaryDomain, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" />
-                                                </DataTemplate>
-                                            </DataGridTemplateColumn.CellTemplate>
-                                        </DataGridTemplateColumn>
-                                    </DataGrid.Columns>
-                                </DataGrid>
-                            </StackPanel>
-                        </StackPanel>
-                    </StackPanel>
-                </StackPanel>
-            </TabItem>
+											<DataGridCheckBoxColumn Header="Include" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" />
+											<DataGridTextColumn Header="Domain" Binding="{Binding Domain, UpdateSourceTrigger=PropertyChanged}" Width="400" IsReadOnly="True" />
+											<DataGridTemplateColumn Header="Primary">
+												<DataGridTemplateColumn.CellTemplate>
+													<DataTemplate>
+														<RadioButton GroupName="PrimaryDomainGroup" IsChecked="{Binding IsPrimaryDomain, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" />
+													</DataTemplate>
+												</DataGridTemplateColumn.CellTemplate>
+											</DataGridTemplateColumn>
+										</DataGrid.Columns>
+									</DataGrid>
+								</StackPanel>
+							</StackPanel>
+						</StackPanel>
+					</StackPanel>
+				</ScrollViewer>
+			</TabItem>
             <TabItem Header="Advanced" IsSelected="True">
-                <StackPanel Margin="0,16,0,0">
+				<ScrollViewer VerticalScrollBarVisibility="Auto">
+					<StackPanel Margin="0,16,0,0">
 
-                    <StackPanel Orientation="Vertical" Margin="8,0,0,0">
-                        <CheckBox Content="Perform challenge response config checks" IsChecked="{Binding SelectedItem.RequestConfig.PerformExtensionlessConfigChecks}" />
-                        <CheckBox Content="Perform web application auto config" IsChecked="{Binding SelectedItem.RequestConfig.PerformAutoConfig}" />
-                    </StackPanel>
+						<StackPanel Orientation="Horizontal" Margin="8,0,0,0">
+							<Label Width="155" Content="Website Root Directory"/>
+							<TextBox Text="{Binding SelectedItem.RequestConfig.WebsiteRootPath}" Width="350"/>
+							<Button Name="Button_WebRoot" Content="..." Margin="4,0,0,0" Click="DirectoryBrowse_Click"/>
+						</StackPanel>
 
-                    <StackPanel Orientation="Vertical" Margin="8,16,0,0">
-                        <RadioButton IsChecked="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding}" GroupName="BindingType" Content="Auto create/update IIS bindings (uses SNI)" />
-                        <RadioButton  IsChecked="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding, Converter={StaticResource ResourceKey=InvBoolConverter}}" GroupName="BindingType" Content="Use specific IP/Port bindings" />
-                    </StackPanel>
+						<StackPanel Orientation="Vertical" Margin="8,8,0,0">
+							<CheckBox Content="Perform challenge response config checks" IsChecked="{Binding SelectedItem.RequestConfig.PerformExtensionlessConfigChecks}" />
+							<CheckBox Content="Perform web application auto config" IsChecked="{Binding SelectedItem.RequestConfig.PerformAutoConfig}" />
+						</StackPanel>
 
-                    <StackPanel Orientation="Vertical" IsEnabled="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding, Converter={StaticResource ResourceKey=InvBoolConverter}}" Margin="32,8,0,0">
-                        <StackPanel Orientation="Horizontal">
-                            <Label Width="131" Content="Bind to Specific IP:" />
+						<StackPanel Orientation="Vertical" Margin="8,16,0,0">
+							<RadioButton IsChecked="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding}" GroupName="BindingType" Content="Auto create/update IIS bindings (uses SNI)" />
+							<RadioButton  IsChecked="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding, Converter={StaticResource ResourceKey=InvBoolConverter}}" GroupName="BindingType" Content="Use specific IP/Port bindings" />
+						</StackPanel>
 
-                            <ComboBox ItemsSource="{Binding HostIPAddresses}" SelectedItem="{Binding SelectedItem.RequestConfig.BindingIPAddress}" Width="225" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <Label Width="131" Content="Bind to Specific Port:" />
-                            <TextBox Text="{Binding SelectedItem.RequestConfig.BindingPort}" Width="225" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <Label Width="131" Content="Use SNI (IIS 8+):" />
-                            <CheckBox IsChecked="{Binding SelectedItem.RequestConfig.BindingUseSNI}"></CheckBox>
-                        </StackPanel>
-                    </StackPanel>
-                </StackPanel>
-            </TabItem>
+						<StackPanel Orientation="Vertical" IsEnabled="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding, Converter={StaticResource ResourceKey=InvBoolConverter}}" Margin="32,8,0,0">
+							<StackPanel Orientation="Horizontal">
+								<Label Width="131" Content="Bind to Specific IP:" />
+
+								<ComboBox ItemsSource="{Binding HostIPAddresses}" SelectedItem="{Binding SelectedItem.RequestConfig.BindingIPAddress}" Width="225" />
+							</StackPanel>
+							<StackPanel Orientation="Horizontal">
+								<Label Width="131" Content="Bind to Specific Port:" />
+								<TextBox Text="{Binding SelectedItem.RequestConfig.BindingPort}" Width="225" />
+							</StackPanel>
+							<StackPanel Orientation="Horizontal">
+								<Label Width="131" Content="Use SNI (IIS 8+):" />
+								<CheckBox IsChecked="{Binding SelectedItem.RequestConfig.BindingUseSNI}"></CheckBox>
+							</StackPanel>
+						</StackPanel>
+
+						<StackPanel Orientation="Vertical" Margin="8,16,0,0">
+							<StackPanel Orientation="Horizontal">
+								<Label Width="155" Content="Pre-request PS Script:"/>
+								<TextBox Text="{Binding SelectedItem.RequestConfig.PreRequestPowerShellScript}" Width="350"/>
+								<Button Name="Button_PreRequest" Content="..." Margin="4,0,0,0" Click="FileBrowse_Click"/>
+								<Button Name="Button_TestPreRequest" Content="Test" Margin="4,0,0,0" Click="TestScript_Click"/>
+							</StackPanel>
+							<StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+								<Label Width="155" Content="Post-request PS Script:"/>
+								<TextBox Text="{Binding SelectedItem.RequestConfig.PostRequestPowerShellScript}" Width="350"/>
+								<Button Name="Button_PostRequest" Content="..." Margin="4,0,0,0" Click="FileBrowse_Click"/>
+								<Button Name="Button_TestPostRequest" Content="Test" Margin="4,0,0,0" Click="TestScript_Click"/>
+							</StackPanel>
+						</StackPanel>
+					</StackPanel>
+				</ScrollViewer>
+			</TabItem>
             <TabItem Header="Info" IsSelected="True">
-                <StackPanel Orientation="Vertical">
+				<ScrollViewer VerticalScrollBarVisibility="Auto">
+					<StackPanel Orientation="Vertical">
 
-                    <Button x:Name="OpenLogFile" Content="Open Log File" Click="OpenLogFile_Click" />
-                    <Label x:Name="CertPath" Content="Certificate Path:" />
-                    <Button x:Name="OpenCertificateFile" Content="View Certificate" Click="OpenCertificateFile_Click" />
-                    <Label  Content="Note: To export this certificate use the Manage Computer Certificates option in Windows. " />
-                </StackPanel>
-            </TabItem>
+						<Button x:Name="OpenLogFile" Content="Open Log File" Click="OpenLogFile_Click" />
+						<Label x:Name="CertPath" Content="Certificate Path:" />
+						<Button x:Name="OpenCertificateFile" Content="View Certificate" Click="OpenCertificateFile_Click" />
+						<Label  Content="Note: To export this certificate use the Manage Computer Certificates option in Windows. " />
+					</StackPanel>
+				</ScrollViewer>
+			</TabItem>
         </dragablz:TabablzControl>
     </Grid>
 </UserControl>

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -1,9 +1,13 @@
 ﻿using Certify.Management;
+using Certify.Models;
+using Microsoft.Win32;
 using System;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Windows;
 using System.Windows.Controls;
+using WinForms = System.Windows.Forms;
 
 namespace Certify.UI.Controls
 {
@@ -200,6 +204,84 @@ namespace Certify.UI.Controls
             else
             {
                 MessageBox.Show("The certificate file for this item has not been created yet.");
+            }
+        }
+
+        private void DirectoryBrowse_Click(object sender, EventArgs e)
+        {
+            var config = MainViewModel.SelectedItem.RequestConfig;
+            var dialog = new WinForms.FolderBrowserDialog()
+            {
+                SelectedPath = config.WebsiteRootPath
+            };
+            if (dialog.ShowDialog()==WinForms.DialogResult.OK)
+            {
+                config.WebsiteRootPath = dialog.SelectedPath;
+            }
+        }
+
+        private void FileBrowse_Click(object sender, EventArgs e)
+        {
+            var button = (Button)sender;
+            var config = MainViewModel.SelectedItem.RequestConfig;
+            var dialog = new OpenFileDialog()
+            {
+                Filter = "Powershell Scripts (*.ps1)| *.ps1;"
+            };
+            Action saveAction = null;
+            string filename = "";
+            if (button.Name == "Button_PreRequest")
+            {
+                filename = config.PreRequestPowerShellScript;
+                saveAction = () => config.PreRequestPowerShellScript = dialog.FileName;
+            }
+            else if (button.Name == "Button_PostRequest")
+            {
+                filename = config.PostRequestPowerShellScript;
+                saveAction = () => config.PostRequestPowerShellScript = dialog.FileName;
+            }
+            try
+            {
+                var fileInfo = new FileInfo(filename);
+                if (fileInfo.Directory.Exists)
+                {
+                    dialog.InitialDirectory = fileInfo.Directory.FullName;
+                    dialog.FileName = fileInfo.Name;
+                }
+            }
+            catch (ArgumentException)
+            {
+                // invalid file passed in, open dialog with default options
+            }
+            if (dialog.ShowDialog()==true)
+            {
+                saveAction();
+            }
+        }
+
+        private async void TestScript_Click(object sender, EventArgs e)
+        {
+            var button = (Button)sender;
+            string scriptFile = null;
+            var result = new CertificateRequestResult { ManagedItem = MainViewModel.SelectedItem, IsSuccess = true, Message = "Script Testing Message" };
+            if (button.Name == "Button_TestPreRequest")
+            {
+                scriptFile = MainViewModel.SelectedItem.RequestConfig.PreRequestPowerShellScript;
+                result.IsSuccess = false; // pre-request messages will always have IsSuccess = false
+            }
+            else if (button.Name == "Button_TestPostRequest")
+            {
+                scriptFile = MainViewModel.SelectedItem.RequestConfig.PostRequestPowerShellScript;
+            }
+            if (string.IsNullOrEmpty(scriptFile)) return; // don't try to run empty script
+            try
+            {
+                string scriptOutput = await PowerShellManager.RunScript(result, scriptFile);
+                MessageBox.Show(scriptOutput, "Powershell Output", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (ArgumentException ex)
+            {
+                MessageBox.Show(ex.Message, "Script Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
     }


### PR DESCRIPTION
I realized that RRAS's SSTP VPN (whew, that's a lot of acronyms) could use the SSL certificate installed in IIS by Certify to do VPN encryption, but it wouldn't automatically switch to the auto-renewed certificates until the service was restarted (at least in Windows Server 2008 R2). I figured that was a good use case for a request hook as talked about in webprofusion/certify#63. I added post- and pre-request hooks as well as the ability to modify the RequestConfig such as updating `ManagedItem.RequestConfig.WebsiteRootPath` as discussed in webprofusion/certify#146.

Also exposed the website root directory in the UI in case there is a special directory (like ASP.NET Core's convention for storing static files in wwwroot) that the challenge files should be based out of:

![screenshot_090917_112604_pm](https://user-images.githubusercontent.com/1369184/30246116-41b8eed2-95b6-11e7-8511-f2e3be19f160.jpg)

Example script: `restart rras.ps1`
```powershell
param($result)
if ($result.IsSuccess) {
	write-output "Restarting RRAS"
	Net Stop RemoteAccess
	Net Start RemoteAccess
	write-output "Done"
}
```

I also tested out auto-updating the WebsiteRootDirectory: `test.ps1`
```powershell
param($result)
$id = $result.ManagedItem.GroupId
[xml]$xml = . "$env:windir\system32\inetsrv\appcmd" list config /section:system.applicationHost/sites
$path = $xml.SelectSingleNode("//site[@id=$id]/application[@path='/']/virtualDirectory/@physicalPath").Value
$result.ManagedItem.RequestConfig.WebsiteRootPath = $path
write-output "Path Updated: $path"
```

This is probably the sort of change that would be good to update the documentation or wiki alongside with making, since it's non-obvious how the hooks work if you didn't already know what they did. Is there any way for me to do that? Thanks!
