### PR TITLE
Determine current website root path during certificate renewal

### DIFF
--- a/src/Certify.Core/Management/CertifyManager.cs
+++ b/src/Certify.Core/Management/CertifyManager.cs
@@ -212,7 +212,7 @@ namespace Certify.Management
                 // start with a failure result, set to success when succeeding
                 var result = new CertificateRequestResult { ManagedItem = managedSite, IsSuccess = false, Message = "" };
 
-                var config = managedSite.RequestConfig;
+                var config = _iisManager.GetCurrentCertRequestConfig(managedSite);
                 try
                 {
                     // run pre-request script, if set
@@ -585,8 +585,7 @@ namespace Certify.Management
                         PerformChallengeFileCopy = true,
                         PerformExtensionlessConfigChecks = true,
                         PrimaryDomain = identifier.Dns,
-                        SubjectAlternativeNames = new string[] { identifier.Dns },
-                        WebsiteRootPath = iisSite?.PhysicalPath
+                        SubjectAlternativeNames = new string[] { identifier.Dns }
                     }
                 };
                 site.AddDomainOption(new DomainOption { Domain = identifier.Dns, IsPrimaryDomain = true, IsSelected = true });

--- a/src/Certify.Core/Management/IISManager.cs
+++ b/src/Certify.Core/Management/IISManager.cs
@@ -373,6 +373,31 @@ namespace Certify.Management
         }
 
         /// <summary>
+        /// Finds the IIS <see cref="Site"/> corresponding to a <see cref="ManagedSite"/>.
+        /// </summary>
+        /// <param name="managedSite">Configured site.</param>
+        /// <returns>The matching IIS Site if found, otherwise null.</returns>
+        private Site FindManagedSite(ManagedSite managedSite)
+        {
+            if (managedSite == null)
+                throw new ArgumentNullException(nameof(managedSite));
+
+            var site = GetSiteById(managedSite.GroupId);
+
+            if (site != null)
+            {
+                //TODO: check site has bindings for given domains, otherwise set back to null
+            }
+
+            if (site == null)
+            {
+                site = GetSiteByDomain(managedSite.RequestConfig.PrimaryDomain);
+            }
+
+            return site;
+        }
+
+        /// <summary>
         /// Gets the current certificate request configuration for a site.
         /// </summary>
         /// <param name="managedSite">Configured site.</param>
@@ -383,7 +408,7 @@ namespace Certify.Management
                 throw new ArgumentNullException(nameof(managedSite));
 
             var config = new CertRequestConfig(managedSite.RequestConfig);
-            var site = GetSiteById(managedSite.GroupId);
+            var site = FindManagedSite(managedSite);
 
             // if the path hasn't been set, attempt to get the current path from IIS
             if (site != null && string.IsNullOrEmpty(config.WebsiteRootPath))
@@ -417,6 +442,8 @@ namespace Certify.Management
 
             if (storedCert != null)
             {
+                var site = FindManagedSite(managedSite);
+
                 //get list of domains we need to create/update https bindings for
                 List<string> dnsHosts = new List<string> { requestConfig.PrimaryDomain };
                 if (requestConfig.SubjectAlternativeNames != null)
@@ -425,19 +452,6 @@ namespace Certify.Management
                 }
 
                 dnsHosts = dnsHosts.Distinct().ToList();
-
-                // identify the IIS set we want to target
-                var site = GetSiteById(managedSite.GroupId);
-
-                if (site != null)
-                {
-                    //TODO: check site has bindings for given domains, otherwise set back to null
-                }
-
-                if (site == null)
-                {
-                    site = GetSiteByDomain(dnsHosts.FirstOrDefault(d => !String.IsNullOrWhiteSpace(d)));
-                }
 
                 // add/update required bindings for each dns hostname
                 foreach (var hostname in dnsHosts)

--- a/src/Certify.Core/Models/CertRequestConfig.cs
+++ b/src/Certify.Core/Models/CertRequestConfig.cs
@@ -10,6 +10,29 @@ namespace Certify.Models
 {
     public class CertRequestConfig : BindableBase
     {
+        public CertRequestConfig()
+        {
+        }
+
+        public CertRequestConfig(CertRequestConfig config)
+        {
+            // copy constructor
+            PrimaryDomain = config.PrimaryDomain;
+            SubjectAlternativeNames = config.SubjectAlternativeNames;
+            WebsiteRootPath = config.WebsiteRootPath;
+            BindingIPAddress = config.BindingIPAddress;
+            BindingPort = config.BindingPort;
+            BindingUseSNI = config.BindingUseSNI;
+            PerformChallengeFileCopy = config.PerformChallengeFileCopy;
+            PerformExtensionlessConfigChecks = config.PerformExtensionlessConfigChecks;
+            PerformAutoConfig = config.PerformAutoConfig;
+            PerformAutomatedCertBinding = config.PerformAutomatedCertBinding;
+            EnableFailureNotifications = config.EnableFailureNotifications;
+            ChallengeType = config.ChallengeType;
+            PreRequestPowerShellScript = config.PreRequestPowerShellScript;
+            PostRequestPowerShellScript = config.PostRequestPowerShellScript;
+        }
+
         /// <summary>
         /// Primary subject domain for our SSL Cert request
         /// </summary>

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -520,8 +520,6 @@ namespace Certify.UI.ViewModel
 
                 item.Id = Guid.NewGuid().ToString() + ":" + siteInfo.SiteId;
                 item.GroupId = siteInfo.SiteId;
-
-                config.WebsiteRootPath = Environment.ExpandEnvironmentVariables(siteInfo.PhysicalPath);
             }
 
             item.ItemType = ManagedItemType.SSL_LetsEncrypt_LocalIIS;


### PR DESCRIPTION
Allows omitting the Website Root Path from the `ManagedSite` configuration so that it can be determined at the time of certificate renewal instead.
 - If the website root path is provided, it will be used during certificate renewal.
 - If the path is not provided, then the current website root path is determined based on the IIS configuration for the matching IIS Site by Site Id.

This satisfies the deployment scenario in #146 by simply omitting the path while still supporting existing scenarios where it may be desirable to store and always use a particular path.

The default behavior when adding a new managed site configuration has changed to what I feel is the more common scenario (omitting the path).  If desired, the user can still set it in the UI / config file.

It wasn't clear how best to map from a `ManagedSite` to an IIS `Site`, so I used `GroupId` (which is currently the IIS site `Id`) similar to how `InstallCertForRequest` performs the lookup.  Both usages were refactored into a common method `FindManagedSite`.