### PR TITLE
Modify website root updating

### DIFF
--- a/src/Certify.Core/Management/APIProviders/ACMESharpProvider.cs
+++ b/src/Certify.Core/Management/APIProviders/ACMESharpProvider.cs
@@ -99,9 +99,9 @@ namespace Certify.Management.APIProviders
             return _vaultManager.BeginRegistrationAndValidation(config, domainIdentifierId, challengeType, domain);
         }
 
-        public PendingAuthorization PerformIISAutomatedChallengeResponse(CertRequestConfig requestConfig, PendingAuthorization pendingAuth)
+        public PendingAuthorization PerformIISAutomatedChallengeResponse(IISManager iisManager, ManagedSite managedSite, PendingAuthorization pendingAuth)
         {
-            return _vaultManager.PerformIISAutomatedChallengeResponse(requestConfig, pendingAuth);
+            return _vaultManager.PerformIISAutomatedChallengeResponse(iisManager, managedSite, pendingAuth);
         }
 
         public void SubmitChallenge(string domainIdentifierId, string challengeType)

--- a/src/Certify.Core/Management/APIProviders/CertesProvider.cs
+++ b/src/Certify.Core/Management/APIProviders/CertesProvider.cs
@@ -96,7 +96,7 @@ namespace Certify.Management.APIProviders
             throw new NotImplementedException();
         }
 
-        public PendingAuthorization PerformIISAutomatedChallengeResponse(CertRequestConfig requestConfig, PendingAuthorization pendingAuth)
+        public PendingAuthorization PerformIISAutomatedChallengeResponse(IISManager iisManager, ManagedSite managedSite, PendingAuthorization pendingAuth)
         {
             throw new NotImplementedException();
         }

--- a/src/Certify.Core/Management/CertifyManager.cs
+++ b/src/Certify.Core/Management/CertifyManager.cs
@@ -212,7 +212,7 @@ namespace Certify.Management
                 // start with a failure result, set to success when succeeding
                 var result = new CertificateRequestResult { ManagedItem = managedSite, IsSuccess = false, Message = "" };
 
-                var config = _iisManager.GetCurrentCertRequestConfig(managedSite);
+                var config = managedSite.RequestConfig;
                 try
                 {
                     // run pre-request script, if set
@@ -294,7 +294,7 @@ namespace Certify.Management
 
                                     //ask LE to check our answer to their authorization challenge (http), LE will then attempt to fetch our answer, if all accessible and correct (authorized) LE will then allow us to request a certificate
                                     //prepare IIS with answer for the LE challenege
-                                    authorization = _vaultProvider.PerformIISAutomatedChallengeResponse(config, authorization);
+                                    authorization = _vaultProvider.PerformIISAutomatedChallengeResponse(_iisManager, managedSite, authorization);
 
                                     //if we attempted extensionless config checks, report any errors
                                     if (config.PerformAutoConfig && !authorization.ExtensionlessConfigCheckedOK)

--- a/src/Certify.Core/Management/IISManager.cs
+++ b/src/Certify.Core/Management/IISManager.cs
@@ -14,7 +14,6 @@ namespace Certify.Management
     /// <summary>
     /// Model to work with IIS site details.
     /// </summary>
-
     public class IISManager
     {
         #region IIS
@@ -214,9 +213,14 @@ namespace Certify.Management
             return result.OrderBy(r => r.SiteName).ToList();
         }
 
+        public string GetSitePhysicalPath(ManagedSite managedSite)
+        {
+            return GetSitePhysicalPath(FindManagedSite(managedSite));
+        }
+
         private string GetSitePhysicalPath(Site site)
         {
-            return site.Applications["/"].VirtualDirectories["/"].PhysicalPath;
+            return site?.Applications["/"].VirtualDirectories["/"].PhysicalPath;
         }
 
         private SiteBindingItem GetSiteBinding(Site site, Binding binding)
@@ -395,29 +399,6 @@ namespace Certify.Management
             }
 
             return site;
-        }
-
-        /// <summary>
-        /// Gets the current certificate request configuration for a site.
-        /// </summary>
-        /// <param name="managedSite">Configured site.</param>
-        /// <returns>A copy of the request configuration with current values.</returns>
-        internal CertRequestConfig GetCurrentCertRequestConfig(ManagedSite managedSite)
-        {
-            if (managedSite == null)
-                throw new ArgumentNullException(nameof(managedSite));
-
-            var config = new CertRequestConfig(managedSite.RequestConfig);
-            var site = FindManagedSite(managedSite);
-
-            // if the path hasn't been set, attempt to get the current path from IIS
-            if (site != null && string.IsNullOrEmpty(config.WebsiteRootPath))
-                config.WebsiteRootPath = GetSitePhysicalPath(site);
-
-            // expand any environment variables in the path
-            config.WebsiteRootPath = Environment.ExpandEnvironmentVariables(config.WebsiteRootPath);
-
-            return config;
         }
 
         /// <summary>

--- a/src/Certify.Core/Management/IVaultProvider.cs
+++ b/src/Certify.Core/Management/IVaultProvider.cs
@@ -30,7 +30,7 @@ namespace Certify.Management
 
         PendingAuthorization BeginRegistrationAndValidation(CertRequestConfig config, string domainIdentifierId, string challengeType, string domain);
 
-        PendingAuthorization PerformIISAutomatedChallengeResponse(CertRequestConfig requestConfig, PendingAuthorization pendingAuth);
+        PendingAuthorization PerformIISAutomatedChallengeResponse(IISManager iisManager, ManagedSite managedSite, PendingAuthorization pendingAuth);
 
         void SubmitChallenge(string domainIdentifierId, string challengeType);
 

--- a/src/Certify.Core/Models/CertRequestConfig.cs
+++ b/src/Certify.Core/Models/CertRequestConfig.cs
@@ -10,29 +10,6 @@ namespace Certify.Models
 {
     public class CertRequestConfig : BindableBase
     {
-        public CertRequestConfig()
-        {
-        }
-
-        public CertRequestConfig(CertRequestConfig config)
-        {
-            // copy constructor
-            PrimaryDomain = config.PrimaryDomain;
-            SubjectAlternativeNames = config.SubjectAlternativeNames;
-            WebsiteRootPath = config.WebsiteRootPath;
-            BindingIPAddress = config.BindingIPAddress;
-            BindingPort = config.BindingPort;
-            BindingUseSNI = config.BindingUseSNI;
-            PerformChallengeFileCopy = config.PerformChallengeFileCopy;
-            PerformExtensionlessConfigChecks = config.PerformExtensionlessConfigChecks;
-            PerformAutoConfig = config.PerformAutoConfig;
-            PerformAutomatedCertBinding = config.PerformAutomatedCertBinding;
-            EnableFailureNotifications = config.EnableFailureNotifications;
-            ChallengeType = config.ChallengeType;
-            PreRequestPowerShellScript = config.PreRequestPowerShellScript;
-            PostRequestPowerShellScript = config.PostRequestPowerShellScript;
-        }
-
         /// <summary>
         /// Primary subject domain for our SSL Cert request
         /// </summary>


### PR DESCRIPTION
I haven't had a chance to fully test this but wanted to let @mpetito and @webprofusion-chrisc see what I was talking about for the change to PR #149. This would allow the current pre-PR #149 behavior to remain the same, but would introduce the ability for the user to change the WebsiteRootPath in the UI to something like `%websiteroot%` or `%websiteroot%\wwwroot`, and that value would be expanded to the appropriate current value of configured IIS site physical path at the time of the certificate request. This has the added benefit of being able to auto-update the path when using ASP.NET Core MVC (or any other framework that uses a non-root path for hosting static files like "wwwroot" or "Content" or "Public"). 

This change also removes the `CertRequestConfig` cloning code so that the Pre/Post-Request hooks have read/write access to the site and config info being used by the LE cert request. 