### PR TITLE
add managed site list filtering

### DIFF
--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -8,7 +8,8 @@
               xmlns:System="clr-namespace:System;assembly=mscorlib"
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:utils="clr-namespace:Certify.UI.Utils" x:Class="Certify.UI.Controls.ManagedSites"
-             mc:Ignorable="d" Width="970" Height="487">
+             mc:Ignorable="d" Width="970" Height="487"
+             Loaded="UserControl_OnLoaded">
 
     <Grid>
         <Grid.Resources>
@@ -22,26 +23,29 @@
             <ColumnDefinition Width="*"></ColumnDefinition>
         </Grid.ColumnDefinitions>
 
-        <ListView Grid.Column="0" ItemsSource="{Binding ManagedSites}" SelectionChanged="ListView_SelectionChanged" TouchDown="ListView_TouchDown"  SelectionMode="Single" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" BorderBrush="{DynamicResource {x:Static SystemColors.InactiveBorderBrushKey}}">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Vertical" Margin="0,8,0,0">
-                        <StackPanel Orientation="Horizontal">
-                            <fa:FontAwesome Icon="Globe" Margin="0,0,8,0" />
-                            <TextBlock Text="{Binding Name}" FontWeight="Bold" Margin="0,0,8,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrush} }" />
-                        </StackPanel>
+        <StackPanel Grid.Column="0" Margin="0,10,0,0">
+            <TextBox Name="txtFilter" TextChanged="TxtFilter_TextChanged" Controls:TextBoxHelper.Watermark="Filter..."></TextBox>
+            <ListView Name="lvManagedSites" ItemsSource="{Binding ManagedSites}" SelectionChanged="ListView_SelectionChanged" SelectionMode="Single" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" BorderBrush="{DynamicResource {x:Static SystemColors.InactiveBorderBrushKey}}">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Vertical" Margin="0,8,0,0">
+                            <StackPanel Orientation="Horizontal">
+                                <fa:FontAwesome Icon="Globe" Margin="0,0,8,0" />
+                                <TextBlock Text="{Binding Name}" FontWeight="Bold" Margin="0,0,8,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrush} }" />
+                            </StackPanel>
 
-                        <TextBlock Text="{Binding Path=ItemType, Converter={StaticResource EnumConverter}}" Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" Margin="16,0,0,0" FontSize="10" />
-                        <TextBlock Text="{Binding Path=DateExpiry, Converter={StaticResource ExpiryDateConverter}}"  Foreground="{Binding Path=DateExpiry, Converter={StaticResource ExpiryDateColourConverter}}"  Margin="16,0,0,0" FontSize="10" />
-                    </StackPanel>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+                            <TextBlock Text="{Binding Path=ItemType, Converter={StaticResource EnumConverter}}" Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" Margin="16,0,0,0" FontSize="10" />
+                            <TextBlock Text="{Binding Path=DateExpiry, Converter={StaticResource ExpiryDateConverter}}"  Foreground="{Binding Path=DateExpiry, Converter={StaticResource ExpiryDateColourConverter}}"  Margin="16,0,0,0" FontSize="10" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </StackPanel>
         <Grid Grid.Column="1">
             <Grid.RowDefinitions>
                 <RowDefinition></RowDefinition>
             </Grid.RowDefinitions>
-            <local:ManagedItemSettings Grid.Row="0" Visibility="{Binding IsItemSelected, Converter={StaticResource BoolToVisConverter}}"  Width="Auto" BorderBrush="{DynamicResource WindowTitleColorBrush}" Loaded="ManagedItemSettings_Loaded" Margin="0,10,0,0" Height="Auto" />
+            <local:ManagedItemSettings Grid.Row="0" Visibility="{Binding IsItemSelected, Converter={StaticResource BoolToVisConverter}}"  Width="Auto" BorderBrush="{DynamicResource WindowTitleColorBrush}" Margin="0,10,0,0" Height="Auto" />
 
             <StackPanel Grid.Row="0" Visibility="{Binding IsNoItemSelected, Converter={StaticResource BoolToVisConverter}}" Margin="16,0,0,0" Height="Auto">
                 <StackPanel Margin="16,8"  Height="Auto" MinHeight="300" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">

--- a/src/Certify.UI/Controls/ManagedSites.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedSites.xaml.cs
@@ -38,6 +38,14 @@ namespace Certify.UI.Controls
             }
         }
 
+        private void UserControl_OnLoaded(object sender, RoutedEventArgs e)
+        {
+            CollectionViewSource.GetDefaultView(lvManagedSites.ItemsSource).Filter =
+                i => txtFilter.Text.Trim() == "" ||
+                ((Models.ManagedSite)i).Name.IndexOf(txtFilter.Text, StringComparison.OrdinalIgnoreCase) > -1 ||
+                (((Models.ManagedSite)i).DomainOptions?.Any(d => d.Domain.IndexOf(txtFilter.Text, StringComparison.OrdinalIgnoreCase) > -1) ?? false);
+        }
+
         private void ListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (e.AddedItems.Count > 0)
@@ -69,6 +77,11 @@ namespace Certify.UI.Controls
             {
                 // this.MainViewModel.ManagedSites[0].Name = DateTime.Now.ToShortDateString();
             }
+        }
+
+        private void TxtFilter_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            CollectionViewSource.GetDefaultView(lvManagedSites.ItemsSource).Refresh();
         }
     }
 }


### PR DESCRIPTION
Added text search filtering for managed site name and domain name:

![screenshot_092417_040212_pm](https://user-images.githubusercontent.com/1369184/30786837-bbddc8b8-a141-11e7-8468-09e797966a1d.jpg)

Addresses issue #101.