### PR TITLE
Test all domains, centralize settings model updating

### DIFF
--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -303,15 +303,7 @@ namespace Certify.UI.Controls
             else if (MainViewModel.SelectedItem.RequestConfig.ChallengeType != null)
             {
                 Button_TestChallenge.IsEnabled = false;
-                var config = MainViewModel.SelectedItem.RequestConfig;
-                if (config.PrimaryDomain==null)
-                {
-                    // new unsaved managed site, set PrimaryDomain & GroupId
-                    var primaryDomain = MainViewModel.SelectedItem.DomainOptions.FirstOrDefault(d => d.IsPrimaryDomain == true);
-                    var _idnMapping = new System.Globalization.IdnMapping();
-                    config.PrimaryDomain = _idnMapping.GetAscii(primaryDomain.Domain);
-                    MainViewModel.SelectedItem.GroupId = MainViewModel.SelectedWebSite.SiteId;
-                }
+                MainViewModel.UpdateManagedSiteSettings();
 
                 var result = await MainViewModel.TestChallengeResponse(MainViewModel.SelectedItem);
                 if (result.IsOK)

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -167,7 +167,7 @@ namespace Certify.UI.ViewModel
 
         internal void SaveManagedItemChanges()
         {
-            SelectedItem = GetUpdatedManagedSiteSettings();
+            UpdateManagedSiteSettings();
             AddOrUpdateManagedSite(SelectedItem);
 
             MarkAllChangesCompleted();
@@ -485,7 +485,7 @@ namespace Certify.UI.ViewModel
         /// For the given set of options get a new CertRequestConfig to store
         /// </summary>
         /// <returns></returns>
-        private ManagedSite GetUpdatedManagedSiteSettings()
+        public void UpdateManagedSiteSettings()
         {
             var item = SelectedItem;
             var config = item.RequestConfig;
@@ -516,7 +516,6 @@ namespace Certify.UI.ViewModel
             }
 
             item.ItemType = ManagedItemType.SSL_LetsEncrypt_LocalIIS;
-            return item;
         }
 
         private void PopulateManagedSiteSettings(string siteId)
@@ -524,6 +523,7 @@ namespace Certify.UI.ViewModel
             ValidationError = null;
             var managedSite = SelectedItem;
             managedSite.Name = SelectedWebSite.SiteName;
+            managedSite.GroupId = SelectedWebSite.SiteId;
 
             //TODO: if this site would be a duplicate need to increment the site name
 


### PR DESCRIPTION
Cleans up the access to PrimaryDomain and GroupId (re: https://github.com/webprofusion/certify/pull/164#issuecomment-333430638)

Tests all domains when running a simulated challenge response (re: https://github.com/webprofusion/certify/pull/164#issuecomment-333519010) - fixes #165