### PR TITLE
UI Updates

### DIFF
--- a/src/Certify.UI/Certify.UI.csproj
+++ b/src/Certify.UI/Certify.UI.csproj
@@ -113,6 +113,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Utils\ExpiryDateConverter.cs" />
+    <Compile Include="ViewModel\DesignViewModel.cs" />
     <Compile Include="Windows\Feedback.xaml.cs">
       <DependentUpon>Feedback.xaml</DependentUpon>
     </Compile>

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml
@@ -60,63 +60,58 @@
             </Button>
         </StackPanel>
 
-        <dragablz:TabablzControl x:Name="SettingsTab" Margin="8" Grid.Row="2" VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch">
-
+        <dragablz:TabablzControl x:Name="SettingsTab" Margin="8" Grid.Row="2" FixedHeaderCount="3"
+                                 VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch">
             <TabItem Header="Options" IsSelected="True">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="0,16,0,0">
+                    <StackPanel Margin="12" Orientation="Vertical" Visibility="{Binding SelectedItem, Converter={StaticResource ResourceKey=NullVisConverter}}">
                         <StackPanel Orientation="Horizontal" Visibility="{Binding IsWebsiteSelectable, Converter={StaticResource ResourceKey=BoolToVisConverter}}">
                             <Label Width="136" Content="Select IIS Site:" />
                             <ComboBox ItemsSource="{Binding WebSiteList}" SelectedItem="{Binding SelectedWebSite}"  DisplayMemberPath="SiteName" Width="225" SelectionChanged="Website_SelectionChanged" />
                         </StackPanel>
-                        <StackPanel Orientation="Vertical" Visibility="{Binding SelectedItem, Converter={StaticResource ResourceKey=NullVisConverter}}">
-                            <StackPanel Orientation="Horizontal">
-                                <Label Width="136" Content="Display Name:" />
-                                <TextBox Text="{Binding SelectedItem.Name, UpdateSourceTrigger=PropertyChanged}" Width="225" />
+                        <StackPanel Orientation="Horizontal">
+                            <Label Width="136" Content="Display Name:" />
+                            <TextBox Text="{Binding SelectedItem.Name, UpdateSourceTrigger=PropertyChanged}" Width="225" />
+                        </StackPanel>
+                        <StackPanel Orientation="Vertical" Margin="136,8,0,0">
+                            <CheckBox Content="Enable Auto Renewal" IsChecked="{Binding SelectedItem.IncludeInAutoRenew}" />
+                            <CheckBox Content="Notify Primary Contact On Renewal Failure" IsChecked="{Binding SelectedItem.RequestConfig.EnableFailureNotifications}" />
+                        </StackPanel>
+                        <StackPanel x:Name="NoBindings" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=InvBoolVisConverter}}" Orientation="Vertical"  Margin="0,8,0,0">
+                            <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="8,0" FontWeight="Bold" FontFamily="Segoe UI Semibold" Foreground="#FFEA1010"><Run Text="There are no http or https hostname bindings associated with the selected site in IIS. At least one fully qualified hostname (e.g 'github.com') is required to create a certificate." /></TextBlock>
+                        </StackPanel>
+                        <StackPanel x:Name="DomainOptions" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=BoolToVisConverter}}" Orientation="Vertical" Background="#FFF7F7F7">
+                            <StackPanel Orientation="Vertical" Margin="0,8,8,8" HorizontalAlignment="Left">
+                                <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="8,0,0,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" FontWeight="Bold" FontFamily="Segoe UI Semibold"><Run Text="The following selected domains will be included as a single certificate request. The Lets Encrypt service must be able to access all of these domains via port 80 (for HTTP challenges) or port 443 (for TLS-SNI challenges) for the certification process to work." /></TextBlock>
                             </StackPanel>
-                            <StackPanel Orientation="Vertical" Margin="136,8,0,0">
-                                <CheckBox Content="Enable Auto Renewal" IsChecked="{Binding SelectedItem.IncludeInAutoRenew}" />
-                                <CheckBox Content="Notify Primary Contact On Renewal Failure" IsChecked="{Binding SelectedItem.RequestConfig.EnableFailureNotifications}" />
+                            <StackPanel Orientation="Horizontal" Margin="0,0,8,8">
+                                <Label Content="Domains and Subdomains to include:" />
+                                <Button Content="Select All" Command="{Binding SANSelectAllCommand}" Margin="16,0,0,0" />
+                                <Button Content="Select None" Command="{Binding SANSelectNoneCommand}" Margin="8,0,0,0" />
                             </StackPanel>
-                            <StackPanel x:Name="NoBindings" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=InvBoolVisConverter}}" Orientation="Vertical"  Margin="0,8,0,0">
-                                <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="16,0" FontWeight="Bold" FontFamily="Segoe UI Semibold" Foreground="#FFEA1010"><Run Text="There are no http or https hostname bindings associated with the selected site in IIS. At least one fully qualified hostname (e.g 'github.com') is required to create a certificate." /></TextBlock>
-                            </StackPanel>
-                            <StackPanel x:Name="DomainOptions" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=BoolToVisConverter}}" Orientation="Vertical" Background="#FFF7F7F7" Margin="0,8,0,0">
-                                <StackPanel Orientation="Vertical" Margin="0,16,0,16" HorizontalAlignment="Left">
-                                    <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="8,0,0,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" FontWeight="Bold" FontFamily="Segoe UI Semibold"><Run Text="The following selected domains will be included as a single certificate request. The Lets Encrypt service must be able to access all of theses domains via HTTP (port 80) for the certification process to work." /></TextBlock>
-                                </StackPanel>
-
-                                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                    <Label Content="Domains and Subdomains to include:" />
-                                    <Button Content="Select All" Command="{Binding SANSelectAllCommand}" Margin="16,0,0,0" />
-                                    <Button Content="Select None" Command="{Binding SANSelectNoneCommand}" Margin="8,0,0,0" />
-                                </StackPanel>
-                                <StackPanel Orientation="Vertical">
-
-                                    <DataGrid AutoGenerateColumns="False" CanUserAddRows="False" VerticalScrollBarVisibility="Auto" Height="180" ItemsSource="{Binding SelectedItem.DomainOptions}">
-                                        <DataGrid.Columns>
-
-                                            <DataGridCheckBoxColumn Header="Include" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" />
-                                            <DataGridTextColumn Header="Domain" Binding="{Binding Domain, UpdateSourceTrigger=PropertyChanged}" Width="400" IsReadOnly="True" />
-                                            <DataGridTemplateColumn Header="Primary">
-                                                <DataGridTemplateColumn.CellTemplate>
-                                                    <DataTemplate>
-                                                        <RadioButton GroupName="PrimaryDomainGroup" IsChecked="{Binding IsPrimaryDomain, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" />
-                                                    </DataTemplate>
-                                                </DataGridTemplateColumn.CellTemplate>
-                                            </DataGridTemplateColumn>
-                                        </DataGrid.Columns>
-                                    </DataGrid>
-                                </StackPanel>
-                            </StackPanel>
+                            <DockPanel>
+                                <DataGrid AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding SelectedItem.DomainOptions}">
+                                    <DataGrid.Columns>
+                                        <DataGridTemplateColumn Header="Primary">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <RadioButton GroupName="PrimaryDomainGroup" IsChecked="{Binding IsPrimaryDomain, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" />
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                        <DataGridCheckBoxColumn Header="Include" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" />
+                                        <DataGridTextColumn Header="Domain" Binding="{Binding Domain, UpdateSourceTrigger=PropertyChanged}" Width="*" IsReadOnly="True" />
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </DockPanel>
                         </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>
             <TabItem Header="Advanced" IsSelected="True">
-				<ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="0,16,0,0">
-                        <StackPanel Orientation="Horizontal" Margin="4,0,0,0">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                    <StackPanel Margin="12">
+                        <StackPanel Orientation="Horizontal">
                             <Label Width="100" Content="Challenge Type:" />
                             <ComboBox ItemsSource="{Binding ChallengeTypes}" SelectedItem="{Binding SelectedItem.RequestConfig.ChallengeType}" Width="225" />
                             <Button Name="Button_TestChallenge" Content="Test" Margin="4,0,0,0" Click="TestChallenge_Click"/>
@@ -133,13 +128,13 @@
                                     </Style.Triggers>
                                 </Style>
                             </StackPanel.Style>
-                            <StackPanel Orientation="Horizontal" Margin="4,8,0,0">
+                            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                                 <Label Width="155" Content="Website Root Directory"/>
                                 <TextBox Text="{Binding SelectedItem.RequestConfig.WebsiteRootPath}" Width="350"/>
                                 <Button Name="Button_WebRoot" Content="..." Margin="4,0,0,0" Click="DirectoryBrowse_Click"/>
                             </StackPanel>
 
-                            <StackPanel Orientation="Vertical" Margin="8,8,0,0">
+                            <StackPanel Orientation="Vertical" Margin="4,8,0,0">
                                 <CheckBox Content="Perform challenge response config checks" IsChecked="{Binding SelectedItem.RequestConfig.PerformExtensionlessConfigChecks}" />
                                 <CheckBox Content="Perform web application auto config" IsChecked="{Binding SelectedItem.RequestConfig.PerformAutoConfig}" />
                             </StackPanel>
@@ -156,12 +151,12 @@
                                     </Style.Triggers>
                                 </Style>
                             </StackPanel.Style>
-                            <StackPanel Orientation="Vertical" Margin="8,8,0,0">
+                            <StackPanel Orientation="Vertical" Margin="4,8,0,0">
                                 <CheckBox Content="Perform challenge response config checks" IsChecked="{Binding SelectedItem.RequestConfig.PerformTlsSniBindingConfigChecks}" />
                             </StackPanel>
                         </StackPanel>
 
-                        <StackPanel Orientation="Vertical" Margin="8,16,0,0">
+                        <StackPanel Orientation="Vertical" Margin="4,16,0,0">
                             <RadioButton IsChecked="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding}" GroupName="BindingType" Content="Auto create/update IIS bindings (uses SNI)" />
                             <RadioButton IsChecked="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding, Converter={StaticResource ResourceKey=InvBoolConverter}}" GroupName="BindingType" Content="Use specific IP/Port bindings" />
                         </StackPanel>
@@ -181,7 +176,7 @@
 							</StackPanel>
 						</StackPanel>
 
-						<StackPanel Orientation="Vertical" Margin="4,16,0,0">
+						<StackPanel Orientation="Vertical" Margin="0,16,0,0">
 							<StackPanel Orientation="Horizontal">
 								<Label Width="155" Content="Pre-request PS Script:"/>
 								<TextBox Text="{Binding SelectedItem.RequestConfig.PreRequestPowerShellScript}" Width="350"/>
@@ -200,10 +195,9 @@
 			</TabItem>
             <TabItem Header="Info" IsSelected="True">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Orientation="Vertical">
-
+                    <StackPanel Orientation="Vertical" Margin="12">
                         <Button x:Name="OpenLogFile" Content="Open Log File" Click="OpenLogFile_Click" />
-                        <Label x:Name="CertPath" Content="Certificate Path:" />
+                        <Label x:Name="CertPath" Content="{Binding SelectedItem.CertificatePath, TargetNullValue='Certificate Path: [to be set]'}" />
                         <Button x:Name="OpenCertificateFile" Content="View Certificate" Click="OpenCertificateFile_Click" />
                         <Label  Content="Note: To export this certificate use the Manage Computer Certificates option in Windows. " />
                     </StackPanel>

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml
@@ -5,13 +5,14 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dragablz="clr-namespace:Dragablz;assembly=Dragablz"
              xmlns:local="clr-namespace:Certify.UI.Controls"
-    xmlns:fa="http://schemas.fontawesome.io/icons/"
-    xmlns:Custom="http://metro.mahapps.com/winfx/xaml/controls"
-    xmlns:utils="clr-namespace:Certify.UI.Utils"
-    xmlns:acme="clr-namespace:Certify.ACMESharpCompat;assembly=Certify.Core"
-    x:Class="Certify.UI.Controls.ManagedItemSettings"
-             mc:Ignorable="d" Width="697.442" Height="425.672">
-
+             xmlns:certifyui="clr-namespace:Certify.UI"
+             xmlns:fa="http://schemas.fontawesome.io/icons/"
+             xmlns:Custom="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:utils="clr-namespace:Certify.UI.Utils"
+             xmlns:acme="clr-namespace:Certify.ACMESharpCompat;assembly=Certify.Core"
+             x:Class="Certify.UI.Controls.ManagedItemSettings"
+             mc:Ignorable="d" Width="697.442" Height="425.672"
+             d:DataContext="{d:DesignInstance Type=certifyui:DesignViewModel, IsDesignTimeCreatable=True}">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="38"></RowDefinition>

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -67,7 +67,7 @@ namespace Certify.UI.Controls
 
                 if (MainViewModel.PrimarySubjectDomain == null)
                 {
-                    MessageBox.Show("A Primary Domain must be selected", "Save Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show("A Primary Domain must be included", "Save Error", MessageBoxButton.OK, MessageBoxImage.Error);
                     return;
                 }
 

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -33,20 +33,6 @@ namespace Certify.UI.Controls
         private void MainViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             this.SettingsTab.SelectedIndex = 0;
-
-            if (this.MainViewModel.SelectedItem != null)
-            {
-                //populate info
-                if (!String.IsNullOrEmpty(this.MainViewModel.SelectedItem.CertificatePath))
-                {
-                    CertPath.Content = this.MainViewModel.SelectedItem.CertificatePath;
-                }
-            }
-            else
-            {
-                //clear info
-                CertPath.Content = "Certificate Path: ";
-            }
         }
 
         private void Button_Save(object sender, RoutedEventArgs e)

--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -5,11 +5,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
              xmlns:local="clr-namespace:Certify.UI.Controls"
-              xmlns:System="clr-namespace:System;assembly=mscorlib"
-    xmlns:fa="http://schemas.fontawesome.io/icons/"
-    xmlns:utils="clr-namespace:Certify.UI.Utils" x:Class="Certify.UI.Controls.ManagedSites"
+             xmlns:certifyui="clr-namespace:Certify.UI"
+             xmlns:System="clr-namespace:System;assembly=mscorlib"
+             xmlns:fa="http://schemas.fontawesome.io/icons/"
+             xmlns:utils="clr-namespace:Certify.UI.Utils" x:Class="Certify.UI.Controls.ManagedSites"
              mc:Ignorable="d" Width="970" Height="487"
-             Loaded="UserControl_OnLoaded">
+             Loaded="UserControl_OnLoaded"
+             d:DataContext="{d:DesignInstance Type=certifyui:DesignViewModel, IsDesignTimeCreatable=True}">
 
     <Grid>
         <Grid.Resources>

--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -51,14 +51,9 @@
         </Grid>
         <GridSplitter Grid.Column="1" Width="10" HorizontalAlignment="Stretch" Background="White"/>
         <Grid Grid.Column="2">
-            <Grid.RowDefinitions>
-                <RowDefinition></RowDefinition>
-            </Grid.RowDefinitions>
-            <local:ManagedItemSettings Grid.Row="0" Visibility="{Binding IsItemSelected, Converter={StaticResource BoolToVisConverter}}"  Width="Auto" BorderBrush="{DynamicResource WindowTitleColorBrush}" Margin="0,10,0,0" Height="Auto" />
-
-            <StackPanel Grid.Row="0" Visibility="{Binding IsNoItemSelected, Converter={StaticResource BoolToVisConverter}}" Margin="16,0,0,0" Height="Auto">
+            <local:ManagedItemSettings Visibility="{Binding IsItemSelected, Converter={StaticResource BoolToVisConverter}}" BorderBrush="{DynamicResource WindowTitleColorBrush}" Margin="0,10,0,0" Width="Auto" Height="Auto"/>
+            <StackPanel Visibility="{Binding IsNoItemSelected, Converter={StaticResource BoolToVisConverter}}" Margin="16,0,0,0" Height="Auto">
                 <StackPanel Margin="6,8"  Height="Auto" MinHeight="300" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
-
                     <TextBlock TextWrapping="Wrap" FontSize="36" Margin="16,16,0,16"  FontFamily="Segoe UI Light"><Run FontWeight="Bold" FontFamily="Segoe UI Semibold" Text="Certify" /><Run Text=" the " /><Run Text="w" /><Run Text="eb" /></TextBlock>
                     <TextBlock TextWrapping="Wrap" Margin="16,0,0,0" FontSize="14" FontFamily="Segoe UI Light"><Run Text="Free SSL Certificates provided via the Let's Encrypt service (https://letsencrypt.org)." /><LineBreak /><Run /><Run /><LineBreak /><Run Text="Select a Managed Site or select New Certificate to begin." /><Run Text="&#x9;" /></TextBlock>
                 </StackPanel>

--- a/src/Certify.UI/Controls/ManagedSites.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedSites.xaml.cs
@@ -31,11 +31,7 @@ namespace Certify.UI.Controls
         public ManagedSites()
         {
             InitializeComponent();
-
-            if (!System.ComponentModel.DesignerProperties.GetIsInDesignMode(this))
-            {
-                this.DataContext = MainViewModel;
-            }
+            this.DataContext = MainViewModel;
         }
 
         private void UserControl_OnLoaded(object sender, RoutedEventArgs e)

--- a/src/Certify.UI/Controls/Settings.xaml
+++ b/src/Certify.UI/Controls/Settings.xaml
@@ -4,9 +4,11 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:Certify.UI.Controls"
-       xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             xmlns:certifyui="clr-namespace:Certify.UI"
+             xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
              xmlns:fa="http://schemas.fontawesome.io/icons/" xmlns:ViewModel="clr-namespace:Certify.UI.ViewModel" x:Class="Certify.UI.Controls.Settings"
-             mc:Ignorable="d" Height="292.857" Width="525">
+             mc:Ignorable="d" Height="292.857" Width="525"
+             d:DataContext="{d:DesignInstance Type=certifyui:DesignViewModel, IsDesignTimeCreatable=True}">
 
     <StackPanel Orientation="Vertical" Margin="0,8,0,16">
         <StackPanel Orientation="Horizontal" Margin="8,0,10,0" Height="32">

--- a/src/Certify.UI/MainWindow.xaml
+++ b/src/Certify.UI/MainWindow.xaml
@@ -11,7 +11,8 @@
         GlowBrush="{DynamicResource AccentColorBrush}"
         BorderThickness="1"
         mc:Ignorable="d"
-        Title="Certify SSL Certificate Management" WindowTransitionsEnabled="False" TitleCaps="False" Height="668" MinWidth="680" MinHeight="400" Width="1120" WindowStyle="ToolWindow" Loaded="MetroWindow_Loaded" ContentRendered="MetroWindow_ContentRendered">
+        Title="Certify SSL Certificate Management" WindowTransitionsEnabled="False" TitleCaps="False" Height="668" MinWidth="680" MinHeight="400" Width="1120" WindowStyle="ToolWindow" Loaded="MetroWindow_Loaded" ContentRendered="MetroWindow_ContentRendered"
+        d:DataContext="{d:DesignInstance Type=local:DesignViewModel, IsDesignTimeCreatable=True}">
     <Controls:MetroWindow.Resources>
 
         <ResourceDictionary>

--- a/src/Certify.UI/MainWindow.xaml
+++ b/src/Certify.UI/MainWindow.xaml
@@ -27,7 +27,7 @@
             <RowDefinition Height="56"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
         </Grid.RowDefinitions>
-        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8,8,8" VerticalAlignment="Top">
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8,8,0" VerticalAlignment="Top">
 
             <Button Height="32" Margin="8,0,0,5" Click="Button_NewCertificate">
                 <StackPanel Orientation="Horizontal">
@@ -57,7 +57,7 @@
             </StackPanel>
         </StackPanel>
 
-        <dragablz:TabablzControl x:Name="MainTabControl" Grid.Row="1" Margin="8,8,8,8" BorderThickness="0"
+        <dragablz:TabablzControl x:Name="MainTabControl" Grid.Row="1" Margin="8,8,8,8" BorderThickness="0" FixedHeaderCount="4"
                                  SelectedIndex="{Binding MainUITabIndex}" HorizontalContentAlignment="Left" VerticalContentAlignment="Stretch" Height="auto">
 
             <TabItem Header="Managed Sites" IsSelected="True">

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -244,20 +244,7 @@ namespace Certify.UI.ViewModel
 
         public DomainOption PrimarySubjectDomain
         {
-            get
-            {
-                if (SelectedItem != null)
-                {
-                    var primary = SelectedItem.DomainOptions.FirstOrDefault(d => d.IsPrimaryDomain == true);
-                    if (primary != null)
-                    {
-                        return primary;
-                    }
-                }
-
-                return null;
-            }
-
+            get { return SelectedItem?.DomainOptions.FirstOrDefault(d => d.IsPrimaryDomain && d.IsSelected); }
             set
             {
                 foreach (var d in SelectedItem.DomainOptions)

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -18,7 +18,7 @@ namespace Certify.UI.ViewModel
         /// <summary>
         /// Provide single static instance of model for all consumers
         /// </summary>
-        public static AppModel AppViewModel = new AppModel();
+        public static AppModel AppViewModel = AppModel.GetModel();
 
         public const int ProductTypeId = 1;
 
@@ -49,7 +49,7 @@ namespace Certify.UI.ViewModel
         /// </summary>
         public ObservableCollection<Certify.Models.ManagedSite> ImportedManagedSites { get; set; }
 
-        internal void LoadVaultTree()
+        internal virtual void LoadVaultTree()
         {
             List<VaultItem> tree = new List<VaultItem>();
 
@@ -272,7 +272,6 @@ namespace Certify.UI.ViewModel
                         d.IsPrimaryDomain = false;
                     }
                 }
-
                 SelectedItem.IsChanged = true;
             }
         }
@@ -359,10 +358,25 @@ namespace Certify.UI.ViewModel
 
         #region methods
 
+        public static AppModel GetModel()
+        {
+            var stack = new System.Diagnostics.StackTrace();
+            if (stack.GetFrames().Last().GetMethod().Name == "Main")
+            {
+                return new AppModel();
+            }
+            else
+            {
+                return new DesignViewModel();
+            }
+        }
+
         public AppModel()
         {
-            certifyManager = new CertifyManager();
-
+            if (!(this is DesignViewModel))
+            {
+                certifyManager = new CertifyManager();
+            }
             ProgressResults = new ObservableCollection<RequestProgressState>();
         }
 

--- a/src/Certify.UI/ViewModel/DesignViewModel.cs
+++ b/src/Certify.UI/ViewModel/DesignViewModel.cs
@@ -1,0 +1,68 @@
+﻿using Certify.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Certify.UI
+{
+    /// <summary>
+    /// Mock data view model for use in the WPF designer in Visual Studio
+    /// </summary>
+    public class DesignViewModel : ViewModel.AppModel
+    {
+        public DesignViewModel()
+        {
+            // generate 20 mock sites
+            var msites = new List<ManagedSite>();
+            for (int i=1; i<=20; i++)
+            {
+                msites.Add(new ManagedSite()
+                {
+                    Name = $"test{i}.example.org",
+                    ItemType = ManagedItemType.SSL_LetsEncrypt_LocalIIS,
+                    DateExpiry = DateTime.Now.AddDays(60-5*i)
+                });
+            }
+            ManagedSites = new ObservableCollection<ManagedSite>(msites);
+
+            // flesh out the selected site
+            SelectedItem = msites.First();
+            SelectedItem.RequestConfig = new CertRequestConfig()
+            {
+                ChallengeType = ACMESharpCompat.ACMESharpUtils.CHALLENGE_TYPE_SNI,
+                PerformAutomatedCertBinding = true,
+                PreRequestPowerShellScript = @"c:\inetpub\scripts\pre-req-script.ps1",
+                PostRequestPowerShellScript = @"c:\inetpub\scripts\post-req-script.ps1"
+            };
+            SelectedItem.CertificatePath = @"C:\ProgramData\ACMESharp\sysVault\99-ASSET\cert_ident1a2b3c4d-all.pfx";
+            SelectedItem.DomainOptions = new ObservableCollection<DomainOption>();
+            SelectedItem.DomainOptions.Add(new DomainOption()
+            {
+                Domain = SelectedItem.Name,
+                IsPrimaryDomain = true,
+                IsSelected = true
+            });
+            // add lots of mock domains
+            for (int i=1; i<=20; i++)
+            {
+                SelectedItem.DomainOptions.Add(new DomainOption()
+                {
+                    Domain = $"www{i}.{SelectedItem.Name}",
+                    IsSelected = i <= 3
+                });
+            }
+
+            // create mock registration
+            PrimaryContactEmail = "username@example.org";
+        }
+
+        internal override void LoadVaultTree()
+        {
+            List<VaultItem> tree = new List<VaultItem>();
+            VaultTree = tree;
+        }
+    }
+}


### PR DESCRIPTION
Fixed #167 (domain options list wasn't expanding), in the process created mocked view model for the designer so changes can be previewed in Visual Studio (you might need to click the "enable project code" button on the designer to see it): 

![screenshot_100417_035147_pm](https://user-images.githubusercontent.com/1369184/31199088-eedde176-a91b-11e7-9182-21ea8406bddf.jpg)

Also fixed a bug where a managed site could be saved without primary domain if "Include" was unchecked, updated text on the options tab to include reference to port 443 for TLS-SNI, changed some margins around and prevented tab reordering. 