### PR TITLE
Certificate Revocation support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/lib/ACMESharp"]
 	path = src/lib/ACMESharp
 	url = https://github.com/Marcus-L/ACMESharp.git
-	branch = tls-sni
+	branch = certify

--- a/src/Certify.Core/ACMESharpCompat/Helpers.cs
+++ b/src/Certify.Core/ACMESharpCompat/Helpers.cs
@@ -3,6 +3,7 @@ using ACMESharp.JOSE;
 using ACMESharp.PKI;
 using ACMESharp.Vault.Model;
 using System.IO;
+using System.Net;
 
 /*
  * Port of supporting utls for powershell methods from ACMESharp.POSH: https://github.com/ebekker/ACMESharp
@@ -31,6 +32,15 @@ namespace ACMESharp.POSH.Util
             var p = Config.Proxy;
             var _Client = new AcmeClient();
 
+            // depends on https://github.com/ebekker/ACMESharp/pull/300
+            //_Client.UserAgent = $"Certify/{0} {_Client.UserAgent}";
+            //_Client.Language = "en-US, en;q=0.8";
+            _Client.BeforeGetResponseAction = req =>
+            {
+                var version = typeof(ClientHelper).Assembly.GetName().Version;
+                req.UserAgent = $"Certify/{0} {req.UserAgent}";
+                req.Headers[HttpRequestHeader.AcceptLanguage] = "en-US; en;q=0.8";
+            };
             _Client.RootUrl = new Uri(Config.BaseUri);
             _Client.Directory = Config.ServerDirectory;
 

--- a/src/Certify.Core/ACMESharpCompat/Helpers.cs
+++ b/src/Certify.Core/ACMESharpCompat/Helpers.cs
@@ -38,7 +38,7 @@ namespace ACMESharp.POSH.Util
             _Client.BeforeGetResponseAction = req =>
             {
                 var version = typeof(ClientHelper).Assembly.GetName().Version;
-                req.UserAgent = $"Certify/{0} {req.UserAgent}";
+                req.UserAgent = $"Certify/{version} {req.UserAgent}";
                 req.Headers[HttpRequestHeader.AcceptLanguage] = "en-US; en;q=0.8";
             };
             _Client.RootUrl = new Uri(Config.BaseUri);

--- a/src/Certify.Core/Management/APIProviders/ACMESharpProvider.cs
+++ b/src/Certify.Core/Management/APIProviders/ACMESharpProvider.cs
@@ -138,6 +138,11 @@ namespace Certify.Management.APIProviders
             return _vaultManager.PerformCertificateRequestProcess(primaryDnsIdentifier, alternativeDnsIdentifiers);
         }
 
+        public async Task<APIResult> RevokeCertificate(ManagedSite managedSite)
+        {
+            return await _vaultManager.RevokeCertificate(managedSite.CertificatePath);
+        }
+
         #region IACMEClientProvider methods
 
         public bool AddNewRegistrationAndAcceptTOS(string email)

--- a/src/Certify.Core/Management/APIProviders/CertesProvider.cs
+++ b/src/Certify.Core/Management/APIProviders/CertesProvider.cs
@@ -64,6 +64,11 @@ namespace Certify.Management.APIProviders
             throw new NotImplementedException();
         }
 
+        public Task<APIResult> RevokeCertificate(ManagedSite managedSite)
+        {
+            throw new NotImplementedException();
+        }
+
         #region IACMEClientProvider methods
 
         public bool AddNewRegistrationAndAcceptTOS(string email)

--- a/src/Certify.Core/Management/CertifyManager.cs
+++ b/src/Certify.Core/Management/CertifyManager.cs
@@ -97,6 +97,16 @@ namespace Certify.Management
             return await _vaultProvider.TestChallengeResponse(_iisManager, managedSite);
         }
 
+        public async Task<APIResult> RevokeCertificate(ManagedSite managedSite)
+        {
+            var result = await _vaultProvider.RevokeCertificate(managedSite);
+            if (result.IsOK)
+            {
+                managedSite.CertificateRevoked = true;
+            }
+            return result;
+        }
+
         /// <summary>
         /// Test dummy method for async UI testing etc 
         /// </summary>
@@ -446,6 +456,7 @@ namespace Certify.Management
                                 managedSite.DateRenewed = DateTime.Now;
 
                                 managedSite.CertificatePath = pfxPath;
+                                managedSite.CertificateRevoked = false;
 
                                 //ensure certificate contains all the requested domains
                                 var subjectNames = certInfo.GetNameInfo(System.Security.Cryptography.X509Certificates.X509NameType.UpnName, false);

--- a/src/Certify.Core/Management/IVaultProvider.cs
+++ b/src/Certify.Core/Management/IVaultProvider.cs
@@ -41,5 +41,7 @@ namespace Certify.Management
         bool CompleteIdentifierValidationProcess(string alias);
 
         ProcessStepResult PerformCertificateRequestProcess(string primaryDnsIdentifier, string[] alternativeDnsIdentifiers);
+
+        Task<APIResult> RevokeCertificate(ManagedSite managedSite);
     }
 }

--- a/src/Certify.Core/Management/VaultManager.cs
+++ b/src/Certify.Core/Management/VaultManager.cs
@@ -457,6 +457,32 @@ namespace Certify
             }
         }
 
+        public async Task<APIResult> RevokeCertificate(string pfxPath)
+        {
+            var fi = new FileInfo(pfxPath);
+            string certAlias = fi.Name.Replace("-all.pfx", "");
+            return await Task<APIResult>.Run(() =>
+            {
+                try
+                {
+                    return new APIResult()
+                    {
+                        IsOK = true,
+                        Result = ACMESharpUtils.RevokeCertificate(certAlias)
+                    };
+                }
+                catch (Exception ex)
+                {
+                    return new APIResult()
+                    {
+                        IsOK = false,
+                        FailedItemSummary = new List<string>() { $"Certificate revocation error: {ex.Message}" },
+                        Message = ex.Message
+                    };
+                }
+            });
+        }
+
         public bool CertExists(string domainAlias)
         {
             var certRef = "cert_" + domainAlias;

--- a/src/Certify.Core/Models/ManagedItem.cs
+++ b/src/Certify.Core/Models/ManagedItem.cs
@@ -141,6 +141,7 @@ namespace Certify.Models
 
         public string CertificateId { get; set; }
         public string CertificatePath { get; set; }
+        public bool CertificateRevoked { get; set; }
     }
 
     public class ManagedSite : ManagedItem

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml
@@ -283,7 +283,33 @@
                         <Button x:Name="OpenLogFile" Content="Open Log File" Click="OpenLogFile_Click" />
                         <Label x:Name="CertPath" Content="{Binding SelectedItem.CertificatePath, TargetNullValue='Certificate Path: [to be set]'}" />
                         <Button x:Name="OpenCertificateFile" Content="View Certificate" Click="OpenCertificateFile_Click" />
-                        <Label  Content="Note: To export this certificate use the Manage Computer Certificates option in Windows. " />
+                        <Label Content="Note: To export this certificate use the Manage Computer Certificates option in Windows. " />
+                        <Border>
+                            <Border.Style>
+                                <Style>
+                                    <Setter Property="Border.Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding SelectedItem.CertificateRevoked}" Value="False">
+                                            <Setter Property="Border.Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <Button x:Name="RevokeCertificateBtn" Content="Revoke Certificate" Click="RevokeCertificateBtn_Click" Background="#FFFFC7C7"/>
+                        </Border>
+                        <Border>
+                            <Border.Style>
+                                <Style>
+                                    <Setter Property="Border.Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding SelectedItem.CertificateRevoked}" Value="True">
+                                            <Setter Property="Border.Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <Label Content="WARNING: This certificate has been revoked." Background="#FFFFC7C7"/>
+                        </Border>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -364,12 +364,20 @@ namespace Certify.UI.Controls
 
         private async void RevokeCertificateBtn_Click(object sender, RoutedEventArgs e)
         {
+            // check cert exists, if not inform user
+            var certPath = this.MainViewModel.SelectedItem.CertificatePath;
+            if (String.IsNullOrEmpty(certPath) || !File.Exists(certPath))
+            {
+                MessageBox.Show("The certificate file for this item has not been created yet.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
             if (MessageBox.Show("Are you sure you want to revoke this certificate?", "Alert", MessageBoxButton.OKCancel, MessageBoxImage.Exclamation)==MessageBoxResult.OK)
             {
                 try
                 {
                     RevokeCertificateBtn.IsEnabled = false;
-                    var result = await MainViewModel.RevokeCertificate(MainViewModel.SelectedItem);
+                    var result = await MainViewModel.RevokeSelectedItem();
                     if (result.IsOK)
                     {
                         MessageBox.Show("Certificate Revoked.", "Alert", MessageBoxButton.OK, MessageBoxImage.Information);

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -361,5 +361,29 @@ namespace Certify.UI.Controls
                 Button_TestWebhook.IsEnabled = true;
             }
         }
+
+        private async void RevokeCertificateBtn_Click(object sender, RoutedEventArgs e)
+        {
+            if (MessageBox.Show("Are you sure you want to revoke this certificate?", "Alert", MessageBoxButton.OKCancel, MessageBoxImage.Exclamation)==MessageBoxResult.OK)
+            {
+                try
+                {
+                    RevokeCertificateBtn.IsEnabled = false;
+                    var result = await MainViewModel.RevokeCertificate(MainViewModel.SelectedItem);
+                    if (result.IsOK)
+                    {
+                        MessageBox.Show("Certificate Revoked.", "Alert", MessageBoxButton.OK, MessageBoxImage.Information);
+                    }
+                    else
+                    {
+                        MessageBox.Show($"Error Revoking Certificate:\n{result.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
+                }
+                finally
+                {
+                    RevokeCertificateBtn.IsEnabled = true;
+                }
+            }
+        }
     }
 }

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -600,12 +600,14 @@ namespace Certify.UI.ViewModel
             return await certifyManager.TestChallenge(managedSite);
         }
 
-        public async Task<APIResult> RevokeCertificate(ManagedSite managedSite)
+        public async Task<APIResult> RevokeSelectedItem()
         {
+            var managedSite = SelectedItem;
             var result = await certifyManager.RevokeCertificate(managedSite);
             if (result.IsOK)
             {
                 AddOrUpdateManagedSite(managedSite);
+                MarkAllChangesCompleted();
             }
             return result;
         }

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -600,6 +600,16 @@ namespace Certify.UI.ViewModel
             return await certifyManager.TestChallenge(managedSite);
         }
 
+        public async Task<APIResult> RevokeCertificate(ManagedSite managedSite)
+        {
+            var result = await certifyManager.RevokeCertificate(managedSite);
+            if (result.IsOK)
+            {
+                AddOrUpdateManagedSite(managedSite);
+            }
+            return result;
+        }
+
         private void BeginTrackingProgress(RequestProgressState state)
         {
             var existing = ProgressResults.FirstOrDefault(p => p.ManagedItem.Id == state.ManagedItem.Id);


### PR DESCRIPTION
* Switched ACMESharp submodule to marcus-l/acmesharp certify branch (includes the TLS-SNI and revocation PRs). The PR to support revoke-cert is https://github.com/ebekker/ACMESharp/pull/301
* Update to Certify Core and UI

![screenshot_100817_082435_pm](https://user-images.githubusercontent.com/1369184/31323020-b4012984-ac66-11e7-9ec6-cef7640afb47.jpg)
(made the button red and added a confirm step to avoid mistakes)

![screenshot_100817_082450_pm](https://user-images.githubusercontent.com/1369184/31323026-bcede67c-ac66-11e7-9c5e-8720631ff0cc.jpg)
