### PR TITLE
 Switch submodule back to main ACMESharp repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/lib/ACMESharp"]
 	path = src/lib/ACMESharp
-	url = https://github.com/Marcus-L/ACMESharp.git
-	branch = certify
+	url = https://github.com/ebekker/ACMESharp.git
+	branch = master

--- a/src/Certify.Core/ACMESharpCompat/Helpers.cs
+++ b/src/Certify.Core/ACMESharpCompat/Helpers.cs
@@ -32,15 +32,8 @@ namespace ACMESharp.POSH.Util
             var p = Config.Proxy;
             var _Client = new AcmeClient();
 
-            // depends on https://github.com/ebekker/ACMESharp/pull/300
-            //_Client.UserAgent = $"Certify/{0} {_Client.UserAgent}";
-            //_Client.Language = "en-US, en;q=0.8";
-            _Client.BeforeGetResponseAction = req =>
-            {
-                var version = typeof(ClientHelper).Assembly.GetName().Version;
-                req.UserAgent = $"Certify/{version} {req.UserAgent}";
-                req.Headers[HttpRequestHeader.AcceptLanguage] = "en-US; en;q=0.8";
-            };
+            _Client.UserAgent = $"Certify/{0} {_Client.UserAgent}";
+            _Client.Language = "en-US, en;q=0.8";
             _Client.RootUrl = new Uri(Config.BaseUri);
             _Client.Directory = Config.ServerDirectory;
 


### PR DESCRIPTION
My TLS-SNI, Useragent/Language and Revoke PRs were been merged into ACMESharp, so this switches the submodule back to the main project head at https://github.com/ebekker/ACMESharp/commit/3cb30fedb2d597415916b3f1ac9f447816c2e36a