### PR TITLE
UI Fixes and new features plus refactoring

### DIFF
--- a/src/Certify.Core/Management/CertifyManager.cs
+++ b/src/Certify.Core/Management/CertifyManager.cs
@@ -73,11 +73,6 @@ namespace Certify.Management
             return _vaultProvider.GetCertificates();
         }
 
-        public void SetManagedSites(List<ManagedSite> managedSites)
-        {
-            this._siteManager.UpdatedManagedSites(managedSites);
-        }
-
         public void SaveManagedSites(List<ManagedSite> managedSites)
         {
             this._siteManager.UpdatedManagedSites(managedSites);
@@ -710,7 +705,7 @@ namespace Certify.Management
                         SubjectAlternativeNames = new string[] { identifier.Dns }
                     }
                 };
-                site.AddDomainOption(new DomainOption { Domain = identifier.Dns, IsPrimaryDomain = true, IsSelected = true });
+                site.DomainOptions.Add(new DomainOption { Domain = identifier.Dns, IsPrimaryDomain = true, IsSelected = true });
                 sites.Add(site);
             }
 
@@ -730,7 +725,7 @@ namespace Certify.Management
                         );
                         if (mergedSite != null)
                         {
-                            mergedSite.AddDomainOption(new DomainOption { Domain = s.RequestConfig.PrimaryDomain, IsPrimaryDomain = false, IsSelected = true });
+                            mergedSite.DomainOptions.Add(new DomainOption { Domain = s.RequestConfig.PrimaryDomain, IsPrimaryDomain = false, IsSelected = true });
 
                             //use shortest version of domain name as site name
                             if (mergedSite.RequestConfig.PrimaryDomain.Contains(s.RequestConfig.PrimaryDomain))

--- a/src/Certify.Core/Management/CertifyManager.cs
+++ b/src/Certify.Core/Management/CertifyManager.cs
@@ -26,10 +26,7 @@ namespace Certify.Management
             // ACME Sharp is both a vault (config storage) provider and ACME client provider
             _acmeClientProvider = acmeSharp;
             _vaultProvider = acmeSharp;
-
             _siteManager = new ItemManager();
-            _siteManager.LoadSettings();
-
             _iisManager = new IISManager();
         }
 

--- a/src/Certify.Core/Management/ItemManager.cs
+++ b/src/Certify.Core/Management/ItemManager.cs
@@ -1,12 +1,12 @@
-﻿using System;
+﻿using Certify.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Certify.Models;
-using System.IO;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Certify.Management
 {
@@ -89,6 +89,8 @@ namespace Certify.Management
                     }
                 }*/
             }
+            // reset IsChanged as all items have been persisted
+            ManagedSites.ForEach(s => s.IsChanged = false);
         }
 
         public void LoadSettings()
@@ -104,7 +106,7 @@ namespace Certify.Management
                 {
                     // string configData = System.IO.File.ReadAllText(path); this.ManagedSites = Newtonsoft.Json.JsonConvert.DeserializeObject<List<ManagedSite>>(configData);
 
-                    var managedSites = new List<ManagedSite>();
+                    ManagedSites = new List<ManagedSite>();
                     // read managed sites using tokenize stream, this is useful for large files
 
                     using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read))
@@ -120,34 +122,20 @@ namespace Certify.Management
                                         // Load each object from the stream and do something with it
                                         JObject obj = JObject.Load(reader);
                                         var managedSite = obj.ToObject<ManagedSite>();
-                                        managedSites.Add(managedSite);
+                                        ManagedSites.Add(managedSite);
                                     }
                                 }
                             }
                         }
                     }
 
-                    this.ManagedSites = managedSites;
-
-                    //foreach managed site enable change notification for edits to domainoptions
-                    foreach (var s in this.ManagedSites)
-                    {
-                        foreach (var d in s.DomainOptions)
-                        {
-                            d.PropertyChanged += s.DomainOption_PropertyChanged;
-                            d.IsChanged = false;
-                        }
-                    }
+                    // reset IsChanged for all loaded settings
+                    ManagedSites.ForEach(s => s.IsChanged = false);
                 }
             }
             else
             {
                 this.ManagedSites = new List<ManagedSite>();
-            }
-
-            foreach (var s in this.ManagedSites)
-            {
-                s.IsChanged = false;
             }
         }
 

--- a/src/Certify.Core/Management/ItemManager.cs
+++ b/src/Certify.Core/Management/ItemManager.cs
@@ -33,12 +33,6 @@ namespace Certify.Management
             this.ManagedSites = new List<ManagedSite>(); // this.Preview();
         }
 
-        internal void UpdatedManagedSites(List<ManagedSite> managedSites)
-        {
-            this.ManagedSites = managedSites;
-            this.StoreSettings();
-        }
-
         public void StoreSettings()
         {
             string appDataPath = Util.GetAppDataFolder();
@@ -135,7 +129,7 @@ namespace Certify.Management
             }
             else
             {
-                this.ManagedSites = new List<ManagedSite>();
+                ManagedSites = new List<ManagedSite>();
             }
         }
 
@@ -191,37 +185,40 @@ namespace Certify.Management
 
         public List<ManagedSite> GetManagedSites()
         {
-            this.LoadSettings();
+            LoadSettings();
+            return ManagedSites;
+        }
 
-            if (this.ManagedSites == null) this.ManagedSites = new List<ManagedSite>();
-
-            return this.ManagedSites;
+        public void UpdatedManagedSites(List<ManagedSite> managedSites)
+        {
+            ManagedSites = managedSites;
+            StoreSettings();
         }
 
         public void UpdatedManagedSite(ManagedSite managedSite)
         {
-            this.LoadSettings();
-
-            var existingSite = this.ManagedSites.FirstOrDefault(s => s.Id == managedSite.Id);
-            if (existingSite != null)
+            LoadSettings();
+            int index = ManagedSites.FindIndex(s => s.Id == managedSite.Id);
+            if (index == -1)
             {
-                this.ManagedSites.Remove(existingSite);
+                ManagedSites.Add(managedSite);
             }
-
-            this.ManagedSites.Add(managedSite);
-            this.StoreSettings();
+            else
+            {
+                ManagedSites[index] = managedSite;
+            }
+            StoreSettings();
         }
 
         public void DeleteManagedSite(ManagedSite site)
         {
-            this.LoadSettings();
-
-            var existingSite = this.ManagedSites.FirstOrDefault(s => s.Id == site.Id);
+            LoadSettings();
+            var existingSite = ManagedSites.FirstOrDefault(s => s.Id == site.Id);
             if (existingSite != null)
             {
-                this.ManagedSites.Remove(existingSite);
+                ManagedSites.Remove(existingSite);
             }
-            this.StoreSettings();
+            StoreSettings();
         }
     }
 }

--- a/src/Certify.Core/Models/ManagedItem.cs
+++ b/src/Certify.Core/Models/ManagedItem.cs
@@ -103,7 +103,7 @@ namespace Certify.Models
 
         public void OnPropertyChanged(string prop, object before, object after)
         {
-            if (prop != "IsChanged")
+            if (prop != nameof(IsChanged))
             {
                 // auto-update the IsChanged property for standard properties
                 IsChanged = true;
@@ -203,7 +203,8 @@ namespace Certify.Models
                 bb.isChanged = false;
                 var props = obj.GetType().GetProperties();
                 foreach (var prop in props.Where(p =>
-                    p.PropertyType.GetInterfaces().Contains(typeof(ICollection))))
+                    typeof(ICollection).IsAssignableFrom(p.PropertyType) ||
+                    p.PropertyType.IsSubclassOf(typeof(BindableBase))))
                 {
                     object val = prop.GetValue(obj);
                     if (val is ICollection propertyCollection)
@@ -263,6 +264,11 @@ namespace Certify.Models
         public string CertificateId { get; set; }
         public string CertificatePath { get; set; }
         public bool CertificateRevoked { get; set; }
+
+        public override string ToString()
+        {
+            return $"[{Id ?? "null"}]: \"{Name}\"";
+        }
     }
 
     public class ManagedSite : ManagedItem

--- a/src/Certify.Core/Models/VaultItem.cs
+++ b/src/Certify.Core/Models/VaultItem.cs
@@ -9,11 +9,13 @@ namespace Certify.Models
 {
     public class RegistrationItem : VaultItem
     {
+        public RegistrationItem() : base("registration") { }
         public IEnumerable<string> Contacts { get; set; }
     }
 
     public class IdentifierItem : VaultItem
     {
+        public IdentifierItem() : base("identifier") { }
         public string Dns { get; set; }
         public string Status { get; set; }
         public DateTime? AuthorizationExpiry { get; set; }
@@ -24,6 +26,7 @@ namespace Certify.Models
 
     public class CertificateItem : VaultItem
     {
+        public CertificateItem() : base("certificate") { }
     }
 
     public class VaultItem
@@ -34,5 +37,10 @@ namespace Certify.Models
         public string ItemType { get; set; }
 
         public List<VaultItem> Children { get; set; }
+        public VaultItem() { }
+        public VaultItem(string itemType)
+        {
+            ItemType = itemType;
+        }
     }
 }

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml
@@ -26,7 +26,7 @@
         <Grid.Resources>
             <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
             <utils:InverseBooleanConverter x:Key="InvBoolConverter" />
-            <utils:OptionalBooleanToVisibilityConverter True="Hidden" False="Visible" x:Key="InvBoolVisConverter" />
+            <utils:OptionalBooleanToVisibilityConverter True="Collapsed" False="Visible" x:Key="InvBoolVisConverter" />
             <utils:NullVisibilityConverter x:Key="NullCollapsedConverter" />
             <utils:NullVisibilityConverter x:Key="NullVisibleConverter" Null="Visible" NotNull="Collapsed"/>
         </Grid.Resources>
@@ -68,50 +68,51 @@
         <dragablz:TabablzControl x:Name="SettingsTab" Margin="8" Grid.Row="2" FixedHeaderCount="3"
                                  VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
             <TabItem Header="{x:Static Resources:SR.ManagedItemSettings_Tab_Options}" IsSelected="True">
-                <ScrollViewer VerticalScrollBarVisibility="Auto" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-                    <StackPanel Margin="12" Orientation="Vertical" Visibility="{Binding SelectedItem, Converter={StaticResource ResourceKey=NullCollapsedConverter}}">
-                        <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedItem.Id, Converter={StaticResource ResourceKey=NullVisibleConverter}}">
-                            <Label Width="136" Content="{x:Static Resources:SR.ManagedItemSettings_SelectIISSite}" />
-                            <ComboBox ItemsSource="{Binding WebSiteList}" SelectedItem="{Binding SelectedWebSite}"  DisplayMemberPath="SiteName" Width="225" SelectionChanged="Website_SelectionChanged" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <Label Width="136" Content="{x:Static Resources:SR.ManagedItemSettings_DisplayName}" />
-                            <TextBox Text="{Binding SelectedItem.Name, UpdateSourceTrigger=PropertyChanged}" Width="225" />
-                        </StackPanel>
-                        <StackPanel Orientation="Vertical" Margin="136,8,0,0">
-                            <CheckBox Content="{x:Static Resources:SR.ManagedItemSettings_EnableAutoRenewal}" IsChecked="{Binding SelectedItem.IncludeInAutoRenew}" />
-                            <CheckBox Content="{x:Static Resources:SR.ManagedItemSettings_NotifyPrimaryContactOnRenewalFailure}" IsChecked="{Binding SelectedItem.RequestConfig.EnableFailureNotifications}" />
-                        </StackPanel>
-                        <StackPanel x:Name="NoBindings" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=InvBoolVisConverter}}" Orientation="Vertical"  Margin="0,8,0,0">
-                            <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="8,0" FontWeight="Bold" FontFamily="Segoe UI Semibold" Foreground="#FFEA1010"><Run Text="{x:Static Resources:SR.ManagedItemSettings_NoHostNameBindingWarning}" /></TextBlock>
-                        </StackPanel>
-                        <StackPanel x:Name="DomainOptions" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=BoolToVisConverter}}" Orientation="Vertical" Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
-                            <StackPanel Orientation="Vertical" Margin="0,8,8,8" HorizontalAlignment="Left">
-                                <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="8,0,0,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" FontWeight="Bold" FontFamily="Segoe UI Semibold"><Run Text="{x:Static Resources:SR.ManagedItemSettings_DomainIncluded}" /></TextBlock>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Margin="0,0,8,8">
-                                <Label Content="{x:Static Resources:SR.ManagedItemSettings_SelectDomain}" />
-                                <Button Content="{x:Static Resources:SR.SelectAll}" Command="{Binding SANSelectAllCommand}" Margin="16,0,0,0" />
-                                <Button Content="{x:Static Resources:SR.ManagedItemSettings_SelectNone}" Command="{Binding SANSelectNoneCommand}" Margin="8,0,0,0" />
-                            </StackPanel>
-                            <DockPanel>
-                                <DataGrid AutoGenerateColumns="False" CanUserAddRows="False" ItemsSource="{Binding SelectedItem.DomainOptions}">
-                                    <DataGrid.Columns>
-                                        <DataGridTemplateColumn Header="{x:Static Resources:SR.ManagedItemSettings_Primary}">
-                                            <DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate>
-                                                    <RadioButton GroupName="PrimaryDomainGroup" IsChecked="{Binding IsPrimaryDomain, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" />
-                                                </DataTemplate>
-                                            </DataGridTemplateColumn.CellTemplate>
-                                        </DataGridTemplateColumn>
-                                        <DataGridCheckBoxColumn Header="{x:Static Resources:SR.ManagedItemSettings_Include}" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" />
-                                        <DataGridTextColumn Header="{x:Static Resources:SR.ManagedItemSettings_Domain}" Binding="{Binding Domain, UpdateSourceTrigger=PropertyChanged}" Width="*" IsReadOnly="True" />
-                                    </DataGrid.Columns>
-                                </DataGrid>
-                            </DockPanel>
-                        </StackPanel>
+                <DockPanel Margin="12,12,12,0" Visibility="{Binding SelectedItem, Converter={StaticResource ResourceKey=NullCollapsedConverter}}">
+                    <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Visibility="{Binding SelectedItem.Id, Converter={StaticResource ResourceKey=NullVisibleConverter}}">
+                        <Label Width="136" Content="{x:Static Resources:SR.ManagedItemSettings_SelectIISSite}" />
+                        <ComboBox ItemsSource="{Binding WebSiteList}" SelectedItem="{Binding SelectedWebSite}"  DisplayMemberPath="SiteName" Width="225" SelectionChanged="Website_SelectionChanged" />
                     </StackPanel>
-                </ScrollViewer>
+                    <StackPanel DockPanel.Dock="Top" Orientation="Horizontal">
+                        <Label Width="136" Content="{x:Static Resources:SR.ManagedItemSettings_DisplayName}" />
+                        <TextBox Text="{Binding SelectedItem.Name, UpdateSourceTrigger=PropertyChanged}" Width="225" />
+                    </StackPanel>
+                    <StackPanel DockPanel.Dock="Top" Orientation="Vertical" Margin="136,8,0,0">
+                        <CheckBox Content="{x:Static Resources:SR.ManagedItemSettings_EnableAutoRenewal}" IsChecked="{Binding SelectedItem.IncludeInAutoRenew}" />
+                        <CheckBox Content="{x:Static Resources:SR.ManagedItemSettings_NotifyPrimaryContactOnRenewalFailure}" IsChecked="{Binding SelectedItem.RequestConfig.EnableFailureNotifications}" />
+                    </StackPanel>
+                    <StackPanel DockPanel.Dock="Top" x:Name="NoBindings" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=InvBoolVisConverter}}" Orientation="Vertical"  Margin="0,8,0,0">
+                        <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="8,0" FontWeight="Bold" FontFamily="Segoe UI Semibold" Foreground="#FFEA1010"><Run Text="{x:Static Resources:SR.ManagedItemSettings_NoHostNameBindingWarning}" /></TextBlock>
+                    </StackPanel>
+                    <DockPanel DockPanel.Dock="Bottom" x:Name="DomainOptions" Visibility="{Binding HasSelectedItemDomainOptions, Converter={StaticResource ResourceKey=BoolToVisConverter}}" Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" Margin="0,8,0,0">
+                        <StackPanel DockPanel.Dock="Top" Orientation="Vertical" Margin="0,8,8,8" HorizontalAlignment="Left">
+                            <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Top" HorizontalAlignment="Left"  Margin="8,0,0,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" FontWeight="Bold" FontFamily="Segoe UI Semibold"><Run Text="{x:Static Resources:SR.ManagedItemSettings_DomainIncluded}" /></TextBlock>
+                        </StackPanel>
+                        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,8,8">
+                            <Label Content="{x:Static Resources:SR.ManagedItemSettings_SelectDomain}" />
+                            <Button Content="{x:Static Resources:SR.SelectAll}" Command="{Binding SANSelectAllCommand}" Margin="16,0,0,0" />
+                            <Button Content="{x:Static Resources:SR.ManagedItemSettings_SelectNone}" Command="{Binding SANSelectNoneCommand}" Margin="8,0,0,0" />
+                        </StackPanel>
+                        <DataGrid AutoGenerateColumns="False" CanUserAddRows="False" 
+                                  ScrollViewer.CanContentScroll="True"
+                                  VirtualizingPanel.IsVirtualizing="True"
+                                  ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                  ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                  ItemsSource="{Binding SelectedItem.DomainOptions}">
+                            <DataGrid.Columns>
+                                <DataGridTemplateColumn Header="{x:Static Resources:SR.ManagedItemSettings_Primary}">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <RadioButton GroupName="PrimaryDomainGroup" IsChecked="{Binding IsPrimaryDomain, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" />
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                                <DataGridCheckBoxColumn Header="{x:Static Resources:SR.ManagedItemSettings_Include}" Binding="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}" />
+                                <DataGridTextColumn Header="{x:Static Resources:SR.ManagedItemSettings_Domain}" Binding="{Binding Domain, UpdateSourceTrigger=PropertyChanged}" Width="*" IsReadOnly="True" />
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </DockPanel>
+                </DockPanel>
             </TabItem>
             <TabItem Header="{x:Static Resources:SR.Advanced}" IsSelected="True">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml
@@ -27,8 +27,8 @@
             <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
             <utils:InverseBooleanConverter x:Key="InvBoolConverter" />
             <utils:OptionalBooleanToVisibilityConverter True="Hidden" False="Visible" x:Key="InvBoolVisConverter" />
-            <utils:NullVisibilityConverter x:Key="NullVisibleConverter" />
-            <utils:NullVisibilityConverter x:Key="NullHiddenConverter" NullVisible="False"/>
+            <utils:NullVisibilityConverter x:Key="NullCollapsedConverter" />
+            <utils:NullVisibilityConverter x:Key="NullVisibleConverter" Null="Visible" NotNull="Collapsed"/>
         </Grid.Resources>
         <StackPanel Orientation="Vertical" Grid.Row="0">
             <Label Content="{Binding SelectedItem.Name}" Margin="8,0,0,2" FontSize="24" FontFamily="Segoe UI Semilight" />
@@ -69,8 +69,8 @@
                                  VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
             <TabItem Header="{x:Static Resources:SR.ManagedItemSettings_Tab_Options}" IsSelected="True">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-                    <StackPanel Margin="12" Orientation="Vertical" Visibility="{Binding SelectedItem, Converter={StaticResource ResourceKey=NullVisibleConverter}}">
-                        <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedItem?.Id, Converter={StaticResource ResourceKey=NullHiddenConverter}}">
+                    <StackPanel Margin="12" Orientation="Vertical" Visibility="{Binding SelectedItem, Converter={StaticResource ResourceKey=NullCollapsedConverter}}">
+                        <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedItem.Id, Converter={StaticResource ResourceKey=NullVisibleConverter}}">
                             <Label Width="136" Content="{x:Static Resources:SR.ManagedItemSettings_SelectIISSite}" />
                             <ComboBox ItemsSource="{Binding WebSiteList}" SelectedItem="{Binding SelectedWebSite}"  DisplayMemberPath="SiteName" Width="225" SelectionChanged="Website_SelectionChanged" />
                         </StackPanel>

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml
@@ -27,7 +27,8 @@
             <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
             <utils:InverseBooleanConverter x:Key="InvBoolConverter" />
             <utils:OptionalBooleanToVisibilityConverter True="Hidden" False="Visible" x:Key="InvBoolVisConverter" />
-            <utils:NullVisibilityConverter x:Key="NullVisConverter" />
+            <utils:NullVisibilityConverter x:Key="NullVisibleConverter" />
+            <utils:NullVisibilityConverter x:Key="NullHiddenConverter" NullVisible="False"/>
         </Grid.Resources>
         <StackPanel Orientation="Vertical" Grid.Row="0">
             <Label Content="{Binding SelectedItem.Name}" Margin="8,0,0,2" FontSize="24" FontFamily="Segoe UI Semilight" />
@@ -68,8 +69,8 @@
                                  VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
             <TabItem Header="{x:Static Resources:SR.ManagedItemSettings_Tab_Options}" IsSelected="True">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-                    <StackPanel Margin="12" Orientation="Vertical" Visibility="{Binding SelectedItem, Converter={StaticResource ResourceKey=NullVisConverter}}">
-                        <StackPanel Orientation="Horizontal" Visibility="{Binding IsWebsiteSelectable, Converter={StaticResource ResourceKey=BoolToVisConverter}}">
+                    <StackPanel Margin="12" Orientation="Vertical" Visibility="{Binding SelectedItem, Converter={StaticResource ResourceKey=NullVisibleConverter}}">
+                        <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedItem?.Id, Converter={StaticResource ResourceKey=NullHiddenConverter}}">
                             <Label Width="136" Content="{x:Static Resources:SR.ManagedItemSettings_SelectIISSite}" />
                             <ComboBox ItemsSource="{Binding WebSiteList}" SelectedItem="{Binding SelectedWebSite}"  DisplayMemberPath="SiteName" Width="225" SelectionChanged="Website_SelectionChanged" />
                         </StackPanel>

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml
@@ -164,7 +164,7 @@
 
                         <StackPanel Orientation="Vertical" Margin="4,16,0,0">
                             <RadioButton IsChecked="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding}" GroupName="BindingType" Content="{x:Static Resources:SR.ManagedItemSettings_AutoUpdateBinding}" />
-                            <RadioButton IsChecked="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding, Converter={StaticResource ResourceKey=InvBoolConverter}}" GroupName="BindingType" Content="{x:Static Resources:SR.ManagedItemSettings_UseSpecificBinding}" />
+                            <RadioButton IsChecked="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding, Mode=OneWay, Converter={StaticResource ResourceKey=InvBoolConverter}}" GroupName="BindingType" Content="{x:Static Resources:SR.ManagedItemSettings_UseSpecificBinding}" />
                         </StackPanel>
 
                         <StackPanel Orientation="Vertical" IsEnabled="{Binding SelectedItem.RequestConfig.PerformAutomatedCertBinding, Converter={StaticResource ResourceKey=InvBoolConverter}}" Margin="32,8,0,0">

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -120,9 +120,7 @@ namespace Certify.UI.Controls
             else
             {
                 //reload settings for managed sites, discard changes
-                var currentSiteId = MainViewModel.SelectedItem.Id;
-                MainViewModel.LoadSettings();
-                MainViewModel.SelectedItem = MainViewModel.ManagedSites.FirstOrDefault(m => m.Id == currentSiteId);
+                MainViewModel.DiscardChanges();
             }
         }
 

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -155,18 +155,11 @@ namespace Certify.UI.Controls
 
         private void Button_Delete(object sender, RoutedEventArgs e)
         {
-            if (this.MainViewModel.SelectedItem.Id != null)
+            MainViewModel.DeleteManagedSite(MainViewModel.SelectedItem);
+            if (MainViewModel.ManagedSites.Count == 0 || MainViewModel.SelectedItem.Id == null)
             {
-                if (MessageBox.Show(SR.ManagedItemSettings_ConfirmDelete, SR.ConfirmDelete, MessageBoxButton.YesNoCancel) == MessageBoxResult.Yes)
-                {
-                    MainViewModel.DeleteManagedSite(MainViewModel.SelectedItem);
-                }
-                else
-                {
-                    return;
-                }
+                MainViewModel.SelectedItem = MainViewModel.ManagedSites.FirstOrDefault();
             }
-            ReturnToDefaultManagedItemView();
         }
 
         private void Website_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -40,7 +40,7 @@ namespace Certify.UI.Controls
 
         private void Button_Save(object sender, RoutedEventArgs e)
         {
-            if (this.MainViewModel.SelectedItemHasChanges)
+            if (MainViewModel.SelectedItem.IsChanged)
             {
                 var item = MainViewModel.SelectedItem;
                 if (item.Id == null && MainViewModel.SelectedWebSite == null)
@@ -124,8 +124,6 @@ namespace Certify.UI.Controls
                 MainViewModel.LoadSettings();
                 MainViewModel.SelectedItem = MainViewModel.ManagedSites.FirstOrDefault(m => m.Id == currentSiteId);
             }
-
-            MainViewModel.MarkAllChangesCompleted();
         }
 
         private void ReturnToDefaultManagedItemView()
@@ -184,11 +182,6 @@ namespace Certify.UI.Controls
                     MainViewModel.PopulateManagedSiteSettingsCommand.Execute(siteId);
                 }
             }
-        }
-
-        private void SANDomain_Toggled(object sender, RoutedEventArgs e)
-        {
-            this.MainViewModel.SelectedItem.IsChanged = true;
         }
 
         private void OpenLogFile_Click(object sender, RoutedEventArgs e)

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -126,7 +126,7 @@ namespace Certify.UI.Controls
 
         private void ReturnToDefaultManagedItemView()
         {
-            MainViewModel.SelectFirstOrDefaultItem();
+            MainViewModel.SelectedItem = MainViewModel.ManagedSites.FirstOrDefault();
         }
 
         private void Button_RequestCertificate(object sender, RoutedEventArgs e)
@@ -155,19 +155,18 @@ namespace Certify.UI.Controls
 
         private void Button_Delete(object sender, RoutedEventArgs e)
         {
-            if (this.MainViewModel.SelectedItem.Id == null)
-            {
-                //item not saved, discard
-                ReturnToDefaultManagedItemView();
-            }
-            else
+            if (this.MainViewModel.SelectedItem.Id != null)
             {
                 if (MessageBox.Show(SR.ManagedItemSettings_ConfirmDelete, SR.ConfirmDelete, MessageBoxButton.YesNoCancel) == MessageBoxResult.Yes)
                 {
-                    this.MainViewModel.DeleteManagedSite(this.MainViewModel.SelectedItem);
-                    ReturnToDefaultManagedItemView();
+                    MainViewModel.DeleteManagedSite(MainViewModel.SelectedItem);
+                }
+                else
+                {
+                    return;
                 }
             }
+            ReturnToDefaultManagedItemView();
         }
 
         private void Website_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -35,7 +35,13 @@
                 <RowDefinition Height="*"></RowDefinition>
             </Grid.RowDefinitions>
             <TextBox Grid.Row="0" Name="txtFilter" TextChanged="TxtFilter_TextChanged" Controls:TextBoxHelper.Watermark="{x:Static res:SR.ManagedSites_Filter}"></TextBox>
-            <ListView Grid.Row="1" Name="lvManagedSites" ItemsSource="{Binding ManagedSites}" SelectionChanged="ListView_SelectionChanged" SelectionMode="Single">
+            <ListView Grid.Row="1" Name="lvManagedSites" ItemsSource="{Binding ManagedSites}" SelectedItem="{Binding SelectedItem}" SelectionMode="Single">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <EventSetter Event="PreviewMouseLeftButtonDown" Handler="ListViewItem_InteractionEvent"/>
+                        <EventSetter Event="PreviewTouchDown" Handler="ListViewItem_InteractionEvent"/>
+                    </Style>
+                </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Vertical" Margin="0,8,0,0">

--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -34,8 +34,8 @@
                 </RowDefinition>
                 <RowDefinition Height="*"></RowDefinition>
             </Grid.RowDefinitions>
-            <TextBox Grid.Row="0" Name="txtFilter" TextChanged="TxtFilter_TextChanged" Controls:TextBoxHelper.Watermark="{x:Static res:SR.ManagedSites_Filter}" Controls:TextBoxHelper.ClearTextButton="True"></TextBox>
-            <ListView Grid.Row="1" Name="lvManagedSites" ItemsSource="{Binding ManagedSites}" SelectedItem="{Binding SelectedItem}" SelectionMode="Single">
+            <TextBox Grid.Row="0" Name="txtFilter" TextChanged="TxtFilter_TextChanged" PreviewKeyDown="TxtFilter_PreviewKeyDown" Controls:TextBoxHelper.Watermark="{x:Static res:SR.ManagedSites_Filter}" Controls:TextBoxHelper.ClearTextButton="True"></TextBox>
+            <ListView Grid.Row="1" Name="lvManagedSites" ItemsSource="{Binding ManagedSites}" SelectedItem="{Binding SelectedItem, Mode=OneWay}" SelectionChanged="lvManagedSites_SelectionChanged" SelectionMode="Single">
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
                         <EventSetter Event="PreviewMouseLeftButtonDown" Handler="ListViewItem_InteractionEvent"/>

--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -40,6 +40,12 @@
                     <Style TargetType="ListViewItem">
                         <EventSetter Event="PreviewMouseLeftButtonDown" Handler="ListViewItem_InteractionEvent"/>
                         <EventSetter Event="PreviewTouchDown" Handler="ListViewItem_InteractionEvent"/>
+                        <EventSetter Event="PreviewKeyDown" Handler="ListViewItem_PreviewKeyDown"/>
+                        <Style.Resources>
+                            <!-- for non-Aero systems (windows server 2008 r2 and below) -->
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black"/>
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#efefef"/>
+                        </Style.Resources>
                     </Style>
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>

--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -16,8 +16,8 @@
 
     <Grid>
         <Grid.Resources>
-            <utils:NullVisibilityConverter x:Key="NullHiddenConverter"/>
-            <utils:NullVisibilityConverter x:Key="NullVisibleConverter" NullVisible="True"/>
+            <utils:NullVisibilityConverter x:Key="NullCollapsedConverter"/>
+            <utils:NullVisibilityConverter x:Key="NullVisibleConverter" Null="Visible" NotNull="Collapsed"/>
             <utils:EnumConverter x:Key="EnumConverter" />
             <utils:ExpiryDateConverter x:Key="ExpiryDateConverter" />
             <utils:ExpiryDateColourConverter x:Key="ExpiryDateColourConverter" />
@@ -65,7 +65,7 @@
         </Grid>
         <GridSplitter Grid.Column="1" Width="10" HorizontalAlignment="Stretch" Background="White" />
         <Grid Grid.Column="2">
-            <local:ManagedItemSettings Visibility="{Binding SelectedItem, Converter={StaticResource NullHiddenConverter}}" BorderBrush="{DynamicResource WindowTitleColorBrush}" Margin="0,10,0,0" Width="Auto" Height="Auto" />
+            <local:ManagedItemSettings Visibility="{Binding SelectedItem, Converter={StaticResource NullCollapsedConverter}}" BorderBrush="{DynamicResource WindowTitleColorBrush}" Margin="0,10,0,0" Width="Auto" Height="Auto" />
             <StackPanel Visibility="{Binding SelectedItem, Converter={StaticResource NullVisibleConverter}}" Margin="16,0,0,0" Height="Auto">
                 <StackPanel Margin="6,8"  Height="Auto" MinHeight="300" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
                     <TextBlock TextWrapping="Wrap" FontSize="36" Margin="16,16,0,16"  FontFamily="Segoe UI Light"><Run FontWeight="Bold" FontFamily="Segoe UI Semibold" Text="Certify" /><Run Text=" the " /><Run Text="w" /><Run Text="eb" /></TextBlock>

--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -16,7 +16,8 @@
 
     <Grid>
         <Grid.Resources>
-            <utils:OptionalBooleanToVisibilityConverter x:Key="BoolToVisConverter" True="Visible" False="Collapsed" />
+            <utils:NullVisibilityConverter x:Key="NullHiddenConverter"/>
+            <utils:NullVisibilityConverter x:Key="NullVisibleConverter" NullVisible="True"/>
             <utils:EnumConverter x:Key="EnumConverter" />
             <utils:ExpiryDateConverter x:Key="ExpiryDateConverter" />
             <utils:ExpiryDateColourConverter x:Key="ExpiryDateColourConverter" />
@@ -52,8 +53,8 @@
         </Grid>
         <GridSplitter Grid.Column="1" Width="10" HorizontalAlignment="Stretch" Background="White" />
         <Grid Grid.Column="2">
-            <local:ManagedItemSettings Visibility="{Binding IsItemSelected, Converter={StaticResource BoolToVisConverter}}" BorderBrush="{DynamicResource WindowTitleColorBrush}" Margin="0,10,0,0" Width="Auto" Height="Auto" />
-            <StackPanel Visibility="{Binding IsNoItemSelected, Converter={StaticResource BoolToVisConverter}}" Margin="16,0,0,0" Height="Auto">
+            <local:ManagedItemSettings Visibility="{Binding SelectedItem, Converter={StaticResource NullHiddenConverter}}" BorderBrush="{DynamicResource WindowTitleColorBrush}" Margin="0,10,0,0" Width="Auto" Height="Auto" />
+            <StackPanel Visibility="{Binding SelectedItem, Converter={StaticResource NullVisibleConverter}}" Margin="16,0,0,0" Height="Auto">
                 <StackPanel Margin="6,8"  Height="Auto" MinHeight="300" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
                     <TextBlock TextWrapping="Wrap" FontSize="36" Margin="16,16,0,16"  FontFamily="Segoe UI Light"><Run FontWeight="Bold" FontFamily="Segoe UI Semibold" Text="Certify" /><Run Text=" the " /><Run Text="w" /><Run Text="eb" /></TextBlock>
                     <TextBlock TextWrapping="Wrap" Margin="16,0,0,0" FontSize="14" FontFamily="Segoe UI Light"><Run Text="{x:Static res:SR.ManagedSites_NoItemSelectedDesc}" /><LineBreak /><Run /><Run /><LineBreak /><Run Text="{x:Static res:SR.ManagedSites_NoItemSelectedTip}" /><Run Text="&#x9;" /></TextBlock>

--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -34,7 +34,7 @@
                 </RowDefinition>
                 <RowDefinition Height="*"></RowDefinition>
             </Grid.RowDefinitions>
-            <TextBox Grid.Row="0" Name="txtFilter" TextChanged="TxtFilter_TextChanged" Controls:TextBoxHelper.Watermark="{x:Static res:SR.ManagedSites_Filter}"></TextBox>
+            <TextBox Grid.Row="0" Name="txtFilter" TextChanged="TxtFilter_TextChanged" Controls:TextBoxHelper.Watermark="{x:Static res:SR.ManagedSites_Filter}" Controls:TextBoxHelper.ClearTextButton="True"></TextBox>
             <ListView Grid.Row="1" Name="lvManagedSites" ItemsSource="{Binding ManagedSites}" SelectedItem="{Binding SelectedItem}" SelectionMode="Single">
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">

--- a/src/Certify.UI/Controls/ManagedSites.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedSites.xaml.cs
@@ -1,3 +1,4 @@
+using Certify.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,8 +16,6 @@ using System.Windows.Shapes;
 
 namespace Certify.UI.Controls
 {
-    using Resources;
-
     /// <summary>
     /// Interaction logic for ManagedSites.xaml
     /// </summary>
@@ -48,19 +47,17 @@ namespace Certify.UI.Controls
             };
         }
 
-        private void ListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private void ListViewItem_InteractionEvent(object sender, InputEventArgs e)
         {
-            if (e.AddedItems.Count > 0)
+            var item = (ListViewItem)sender;
+            var site = (ManagedSite)item.DataContext;
+            bool changingSelection = MainViewModel.SelectedItem != site ||
+                (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl));
+
+            if (changingSelection && !MainViewModel.ConfirmDiscardUnsavedChanges())
             {
-                if (MainViewModel.SelectedItem != null && MainViewModel.SelectedItemHasChanges && MainViewModel.SelectedItem.Id != null)
-                {
-                    //user needs to save or discard changes before changing selection
-                    MessageBox.Show(SR.ManagedSites_UnsavedWarning);
-                }
-                else
-                {
-                    MainViewModel.SelectedItem = (Certify.Models.ManagedSite)e.AddedItems[0];
-                }
+                // user did not want to discard changes, ignore click
+                e.Handled = true;
             }
         }
 

--- a/src/Certify.UI/Controls/ManagedSites.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedSites.xaml.cs
@@ -7,12 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace Certify.UI.Controls
 {
@@ -21,7 +16,7 @@ namespace Certify.UI.Controls
     /// </summary>
     public partial class ManagedSites
     {
-        protected Certify.UI.ViewModel.AppModel MainViewModel
+        protected ViewModel.AppModel MainViewModel
         {
             get
             {
@@ -58,22 +53,6 @@ namespace Certify.UI.Controls
             {
                 // user did not want to discard changes, ignore click
                 e.Handled = true;
-            }
-        }
-
-        private void ListView_TouchDown(object sender, TouchEventArgs e)
-        {
-        }
-
-        private void ManagedItemSettings_Loaded(object sender, RoutedEventArgs e)
-        {
-        }
-
-        private void Button_Click(object sender, RoutedEventArgs e)
-        {
-            if (MainViewModel.ManagedSites != null && MainViewModel.ManagedSites.Any())
-            {
-                // this.MainViewModel.ManagedSites[0].Name = DateTime.Now.ToShortDateString();
             }
         }
 

--- a/src/Certify.UI/Controls/ManagedSites.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedSites.xaml.cs
@@ -60,7 +60,6 @@ namespace Certify.UI.Controls
                 else
                 {
                     MainViewModel.SelectedItem = (Certify.Models.ManagedSite)e.AddedItems[0];
-                    MainViewModel.MarkAllChangesCompleted();
                 }
             }
         }

--- a/src/Certify.UI/Controls/ManagedSites.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedSites.xaml.cs
@@ -16,18 +16,12 @@ namespace Certify.UI.Controls
     /// </summary>
     public partial class ManagedSites
     {
-        protected ViewModel.AppModel MainViewModel
-        {
-            get
-            {
-                return ViewModel.AppModel.AppViewModel;
-            }
-        }
+        protected ViewModel.AppModel MainViewModel => ViewModel.AppModel.AppViewModel;
 
         public ManagedSites()
         {
             InitializeComponent();
-            this.DataContext = MainViewModel;
+            DataContext = MainViewModel;
         }
 
         private void UserControl_OnLoaded(object sender, RoutedEventArgs e)

--- a/src/Certify.UI/Controls/Settings.xaml.cs
+++ b/src/Certify.UI/Controls/Settings.xaml.cs
@@ -30,7 +30,6 @@ namespace Certify.UI.Controls
         }
 
         private bool settingsInitialised = false;
-        private bool hasChanges = false;
 
         public Settings()
         {
@@ -97,7 +96,6 @@ namespace Certify.UI.Controls
                 if (this.RenewalMaxRequests.Value == null) this.RenewalMaxRequests.Value = 0;
                 if (this.RenewalMaxRequests.Value > 100) this.RenewalMaxRequests.Value = 100;
                 CoreAppSettings.Current.MaxRenewalRequests = (int)this.RenewalMaxRequests.Value;
-                hasChanges = true;
                 Save.IsEnabled = true;
             }
         }
@@ -121,7 +119,6 @@ namespace Certify.UI.Controls
         private void Save_Click(object sender, RoutedEventArgs e)
         {
             SettingsManager.SaveAppSettings();
-            hasChanges = false;
             Save.IsEnabled = false;
         }
     }

--- a/src/Certify.UI/MainWindow.xaml
+++ b/src/Certify.UI/MainWindow.xaml
@@ -13,7 +13,8 @@
         BorderThickness="1"
         mc:Ignorable="d"
         Title="Certify the web - SSL Certificate Management" WindowTransitionsEnabled="False" TitleCaps="False" Height="668" MinWidth="680" MinHeight="400" Width="1120" WindowStyle="ToolWindow" Loaded="MetroWindow_Loaded" ContentRendered="MetroWindow_ContentRendered"
-        d:DataContext="{d:DesignInstance Type=local:DesignViewModel, IsDesignTimeCreatable=True}">
+        d:DataContext="{d:DesignInstance Type=local:DesignViewModel, IsDesignTimeCreatable=True}"
+        Closing="MetroWindow_Closing">
 
     <Controls:MetroWindow.Resources>
         <ResourceDictionary>

--- a/src/Certify.UI/MainWindow.xaml.cs
+++ b/src/Certify.UI/MainWindow.xaml.cs
@@ -1,5 +1,7 @@
+using Certify.UI.Resources;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,8 +17,6 @@ using System.Windows.Shapes;
 
 namespace Certify.UI
 {
-    using Resources;
-
     /// <summary>
     /// Interaction logic for MainWindow.xaml 
     /// </summary>
@@ -49,6 +49,9 @@ namespace Certify.UI
 
         private void Button_NewCertificate(object sender, RoutedEventArgs e)
         {
+            // save or discard site changes before creating a new site/certificate
+            if (!MainViewModel.ConfirmDiscardUnsavedChanges()) return;
+
             //present new managed item (certificate request) UI
             if (!MainViewModel.IsRegisteredVersion && MainViewModel.ManagedSites != null && MainViewModel.ManagedSites.Count >= 5)
             {
@@ -59,11 +62,15 @@ namespace Certify.UI
             //select tab Managed Items
             MainViewModel.MainUITabIndex = (int)PrimaryUITabs.ManagedItems;
             MainViewModel.SelectedWebSite = null;
+            MainViewModel.SelectedItem = null; // deselect site list item
             MainViewModel.SelectedItem = new Certify.Models.ManagedSite();
         }
 
         private void Button_RenewAll(object sender, RoutedEventArgs e)
         {
+            // save or discard site changes before creating a new site/certificate
+            if (!MainViewModel.ConfirmDiscardUnsavedChanges()) return;
+
             //present new renew all confirmation
             if (MessageBox.Show(SR.MainWindow_RenewAllConfirm, SR.Renew_All, MessageBoxButton.YesNo) == MessageBoxResult.Yes)
             {
@@ -154,6 +161,12 @@ namespace Certify.UI
                     System.Diagnostics.Process.Start(sInfo);
                 }
             }
+        }
+
+        private void MetroWindow_Closing(object sender, CancelEventArgs e)
+        {
+            // allow cancelling exit to save changes
+            if (!MainViewModel.ConfirmDiscardUnsavedChanges()) e.Cancel = true;
         }
     }
 }

--- a/src/Certify.UI/MainWindow.xaml.cs
+++ b/src/Certify.UI/MainWindow.xaml.cs
@@ -40,11 +40,7 @@ namespace Certify.UI
         public MainWindow()
         {
             InitializeComponent();
-
-            if (!System.ComponentModel.DesignerProperties.GetIsInDesignMode(this))
-            {
-                this.DataContext = MainViewModel;
-            }
+            DataContext = MainViewModel;
         }
 
         private void Button_NewCertificate(object sender, RoutedEventArgs e)

--- a/src/Certify.UI/Resources/SR.Designer.cs
+++ b/src/Certify.UI/Resources/SR.Designer.cs
@@ -981,7 +981,7 @@ namespace Certify.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have unsaved changes. Save or Discard your changes before proceeding..
+        ///   Looks up a localized string similar to There are unsaved changes to the selected site. Discard changes?.
         /// </summary>
         public static string ManagedSites_UnsavedWarning {
             get {

--- a/src/Certify.UI/Resources/SR.resx
+++ b/src/Certify.UI/Resources/SR.resx
@@ -298,7 +298,7 @@
     <value>Select a Managed Site or select New Certificate to begin.</value>
   </data>
   <data name="ManagedSites_UnsavedWarning" xml:space="preserve">
-    <value>You have unsaved changes. Save or Discard your changes before proceeding.</value>
+    <value>There are unsaved changes to the selected site. Discard changes?</value>
   </data>
   <data name="ProgressMonitor_NoProgress" xml:space="preserve">
     <value>There are no requests currently in progress.</value>

--- a/src/Certify.UI/Resources/SR.zh-Hans.resx
+++ b/src/Certify.UI/Resources/SR.zh-Hans.resx
@@ -376,7 +376,7 @@
     <value>选择一个已管理的站点或选择新建证书来继续。</value>
   </data>
   <data name="ManagedSites_UnsavedWarning" xml:space="preserve">
-    <value>修改未保存，继续前请保存或放弃修改。</value>
+    <value>选择中有未保存的更改。 放弃更改？ </value>
   </data>
   <data name="ProgressMonitor_NoProgress" xml:space="preserve">
     <value>当前没有请求在操作中。</value>

--- a/src/Certify.UI/Utils/BooleanConverters.cs
+++ b/src/Certify.UI/Utils/BooleanConverters.cs
@@ -66,9 +66,11 @@ namespace Certify.UI.Utils
 
     public class NullVisibilityConverter : IValueConverter
     {
+        public bool NullVisible { get; set; }
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value == null ? Visibility.Hidden : Visibility.Visible;
+            return value == null ^ NullVisible ? Visibility.Hidden : Visibility.Visible;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Certify.UI/Utils/BooleanConverters.cs
+++ b/src/Certify.UI/Utils/BooleanConverters.cs
@@ -66,11 +66,12 @@ namespace Certify.UI.Utils
 
     public class NullVisibilityConverter : IValueConverter
     {
-        public bool NullVisible { get; set; }
+        public Visibility Null { get; set; } = Visibility.Collapsed;
+        public Visibility NotNull { get; set; } = Visibility.Visible;
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value == null ^ NullVisible ? Visibility.Hidden : Visibility.Visible;
+            return value == null ? Null : NotNull;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -1,5 +1,6 @@
 ﻿using Certify.Management;
 using Certify.Models;
+using Certify.UI.Resources;
 using PropertyChanged;
 using System;
 using System.Collections.Generic;
@@ -9,6 +10,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using System.Windows.Input;
 
 namespace Certify.UI.ViewModel
@@ -294,6 +296,41 @@ namespace Certify.UI.ViewModel
         public void SaveSettings(object param)
         {
             certifyManager.SaveManagedSites(this.ManagedSites.ToList());
+        }
+
+        public bool ConfirmDiscardUnsavedChanges()
+        {
+            if (SelectedItem?.IsChanged ?? false)
+            {
+                //user needs to save or discard changes before changing selection
+                if (MessageBox.Show(SR.ManagedSites_UnsavedWarning, SR.Alert, MessageBoxButtons.OKCancel, MessageBoxIcon.Warning)==DialogResult.OK)
+                {
+                    DiscardChanges();
+                }
+                else
+                {
+                    // user cancelled out of dialog
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public void DiscardChanges()
+        {
+            if (SelectedItem?.IsChanged ?? false)
+            {
+                if (SelectedItem.Id == null)
+                {
+                    SelectedItem = null;
+                }
+                else
+                {
+                    var id = SelectedItem.Id;
+                    LoadSettings();
+                    SelectedItem = ManagedSites.FirstOrDefault(m => m.Id == id);
+                }
+            }
         }
 
         public async void RenewAll(bool autoRenewalsOnly)

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -201,37 +201,6 @@ namespace Certify.UI.ViewModel
             }
         }
 
-        /// <summary>
-        /// Determine if user should be able to choose/change the Website for the current SelectedItem 
-        /// </summary>
-        public bool IsWebsiteSelectable
-        {
-            get
-            {
-                if (SelectedItem != null && SelectedItem.Id == null)
-                {
-                    return true;
-                }
-                return false;
-            }
-        }
-
-        public bool IsItemSelected
-        {
-            get
-            {
-                return (this.SelectedItem != null);
-            }
-        }
-
-        public bool IsNoItemSelected
-        {
-            get
-            {
-                return (this.SelectedItem == null);
-            }
-        }
-
         public bool IsSelectedItemValid
         {
             get => SelectedItem?.Id != null && !SelectedItem.IsChanged;

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -105,7 +105,7 @@ namespace Certify.UI.ViewModel
             }
         }
 
-        public Certify.Models.ManagedSite SelectedItem { get; set; }
+        public ManagedSite SelectedItem { get; set; }
 
         public bool IsRegisteredVersion { get; set; }
 
@@ -170,11 +170,6 @@ namespace Certify.UI.ViewModel
                     return new List<IPAddress>();
                 }
             }
-        }
-
-        internal void SelectFirstOrDefaultItem()
-        {
-            SelectedItem = ManagedSites.FirstOrDefault();
         }
 
         public SiteBindingItem SelectedWebSite
@@ -293,7 +288,7 @@ namespace Certify.UI.ViewModel
             }*/
         }
 
-        public void SaveSettings(object param)
+        public void SaveSettings()
         {
             certifyManager.SaveManagedSites(this.ManagedSites.ToList());
         }
@@ -394,26 +389,12 @@ namespace Certify.UI.ViewModel
 
         public void SANSelectAll(object o)
         {
-            if (this.SelectedItem != null && this.SelectedItem.DomainOptions != null)
-            {
-                foreach (var opt in this.SelectedItem.DomainOptions)
-                {
-                    opt.IsSelected = true;
-                }
-            }
+            SelectedItem?.DomainOptions.ToList().ForEach(opt => opt.IsSelected = true);
         }
 
         public void SANSelectNone(object o)
         {
-            if (this.SelectedItem != null && this.SelectedItem.DomainOptions != null)
-            {
-                foreach (var opt in this.SelectedItem.DomainOptions)
-                {
-                    opt.IsSelected = false;
-                }
-
-                // RaisePropertyChanged(nameof(SelectedItem));
-            }
+            SelectedItem?.DomainOptions.ToList().ForEach(opt => opt.IsSelected = false);
         }
 
         /// <summary>
@@ -485,7 +466,6 @@ namespace Certify.UI.ViewModel
 
             //TODO: load settings from previously saved managed site?
             RaisePropertyChanged(nameof(PrimarySubjectDomain));
-
             RaisePropertyChanged(nameof(HasSelectedItemDomainOptions));
         }
 

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -20,6 +20,7 @@ namespace Certify.UI.ViewModel
         /// <summary>
         /// Provide single static instance of model for all consumers 
         /// </summary>
+        //public static AppModel AppViewModel = new DesignViewModel(); // for UI testing
         public static AppModel AppViewModel = AppModel.GetModel();
 
         public const int ProductTypeId = 1;
@@ -82,7 +83,7 @@ namespace Certify.UI.ViewModel
         /// </summary>
         public bool IsImportSANMergeMode { get; set; }
 
-        public bool HasRegisteredContacts
+        public virtual bool HasRegisteredContacts
         {
             get
             {
@@ -109,7 +110,7 @@ namespace Certify.UI.ViewModel
 
         public bool IsRegisteredVersion { get; set; }
 
-        public List<SiteBindingItem> WebSiteList
+        public virtual List<SiteBindingItem> WebSiteList
         {
             get
             {
@@ -261,8 +262,8 @@ namespace Certify.UI.ViewModel
             ProgressResults = new ObservableCollection<RequestProgressState>();
         }
 
-        public bool IsIISAvailable => certifyManager.IsIISAvailable;
-        public Version IISVersion => certifyManager.IISVersion;
+        public virtual bool IsIISAvailable => certifyManager.IsIISAvailable;
+        public virtual Version IISVersion => certifyManager.IISVersion;
 
         public void PreviewImport(bool sanMergeMode)
         {
@@ -272,7 +273,7 @@ namespace Certify.UI.ViewModel
             ImportedManagedSites = new ObservableCollection<ManagedSite>(importedSites);
         }
 
-        public void LoadSettings()
+        public virtual void LoadSettings()
         {
             this.ManagedSites = new ObservableCollection<ManagedSite>(certifyManager.GetManagedSites());
             this.ImportedManagedSites = new ObservableCollection<ManagedSite>();
@@ -288,7 +289,7 @@ namespace Certify.UI.ViewModel
             }*/
         }
 
-        public void SaveSettings()
+        public virtual void SaveSettings()
         {
             certifyManager.SaveManagedSites(this.ManagedSites.ToList());
         }
@@ -372,7 +373,7 @@ namespace Certify.UI.ViewModel
             return item;
         }
 
-        internal void DeleteManagedSite(ManagedSite selectedItem)
+        public virtual void DeleteManagedSite(ManagedSite selectedItem)
         {
             var existing = this.ManagedSites.FirstOrDefault(s => s.Id == selectedItem.Id);
 
@@ -454,8 +455,8 @@ namespace Certify.UI.ViewModel
             managedSite.RequestConfig.ChallengeType = ACMESharpCompat.ACMESharpUtils.CHALLENGE_TYPE_HTTP;
             managedSite.IncludeInAutoRenew = true;
             managedSite.DomainOptions.Clear();
-            foreach (var option in certifyManager.GetDomainOptionsFromSite(siteId))
-            {
+            foreach (var option in GetDomainOptionsFromSite(siteId))
+            { 
                 managedSite.DomainOptions.Add(option);
             }
 
@@ -467,6 +468,11 @@ namespace Certify.UI.ViewModel
             //TODO: load settings from previously saved managed site?
             RaisePropertyChanged(nameof(PrimarySubjectDomain));
             RaisePropertyChanged(nameof(HasSelectedItemDomainOptions));
+        }
+
+        protected virtual IEnumerable<DomainOption> GetDomainOptionsFromSite(string siteId)
+        {
+            return certifyManager.GetDomainOptionsFromSite(siteId);
         }
 
         public async void BeginCertificateRequest(string managedItemId)

--- a/src/Certify.UI/ViewModel/DesignViewModel.cs
+++ b/src/Certify.UI/ViewModel/DesignViewModel.cs
@@ -41,7 +41,6 @@ namespace Certify.UI
                 WebhookMethod = Webhook.METHOD_POST
             };
             SelectedItem.CertificatePath = @"C:\ProgramData\ACMESharp\sysVault\99-ASSET\cert_ident1a2b3c4d-all.pfx";
-            SelectedItem.DomainOptions = new ObservableCollection<DomainOption>();
             SelectedItem.DomainOptions.Add(new DomainOption()
             {
                 Domain = SelectedItem.Name,

--- a/src/Certify.UI/ViewModel/DesignViewModel.cs
+++ b/src/Certify.UI/ViewModel/DesignViewModel.cs
@@ -1,70 +1,126 @@
 ﻿using Certify.Models;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace Certify.UI
 {
     /// <summary>
-    /// Mock data view model for use in the WPF designer in Visual Studio
+    /// Mock data view model for use in the XAML designer in Visual Studio
     /// </summary>
     public class DesignViewModel : ViewModel.AppModel
     {
         public DesignViewModel()
         {
-            // generate 20 mock sites
-            var msites = new List<ManagedSite>();
-            for (int i=1; i<=20; i++)
-            {
-                msites.Add(new ManagedSite()
-                {
-                    Name = $"test{i}.example.org",
-                    ItemType = ManagedItemType.SSL_LetsEncrypt_LocalIIS,
-                    DateExpiry = DateTime.Now.AddDays(60-5*i)
-                });
-            }
-            ManagedSites = new ObservableCollection<ManagedSite>(msites);
-
-            // flesh out the selected site
-            SelectedItem = msites.First();
-            SelectedItem.RequestConfig = new CertRequestConfig()
-            {
-                ChallengeType = ACMESharpCompat.ACMESharpUtils.CHALLENGE_TYPE_SNI,
-                PerformAutomatedCertBinding = true,
-                PreRequestPowerShellScript = @"c:\inetpub\scripts\pre-req-script.ps1",
-                PostRequestPowerShellScript = @"c:\inetpub\scripts\post-req-script.ps1",
-                WebhookTrigger = Webhook.ON_SUCCESS,
-                WebhookUrl = "https://certifytheweb.com/api/notify?domain=$domain&key=123456",
-                WebhookMethod = Webhook.METHOD_POST
-            };
-            SelectedItem.CertificatePath = @"C:\ProgramData\ACMESharp\sysVault\99-ASSET\cert_ident1a2b3c4d-all.pfx";
-            SelectedItem.DomainOptions.Add(new DomainOption()
-            {
-                Domain = SelectedItem.Name,
-                IsPrimaryDomain = true,
-                IsSelected = true
-            });
-            // add lots of mock domains
-            for (int i=1; i<=20; i++)
-            {
-                SelectedItem.DomainOptions.Add(new DomainOption()
-                {
-                    Domain = $"www{i}.{SelectedItem.Name}",
-                    IsSelected = i <= 3
-                });
-            }
-
             // create mock registration
             PrimaryContactEmail = "username@example.org";
+
+            // generate mock data starting point
+            GenerateMockData();
+            SaveSettings();
+
+            // auto-load data if in WPF designer
+            bool inDesignMode = !(Application.Current is App);
+            if (inDesignMode)
+            {
+                SelectedItem = ManagedSites.First();
+            }
         }
 
         internal override void LoadVaultTree()
         {
             List<VaultItem> tree = new List<VaultItem>();
             VaultTree = tree;
+        }
+
+        private void GenerateMockData()
+        {
+            // generate 20 mock sites
+            ManagedSites = new ObservableCollection<ManagedSite>();
+            for (int i = 1; i <= 20; i++)
+            {
+                var site = new ManagedSite()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Name = $"test{i}.example.org",
+                    ItemType = ManagedItemType.SSL_LetsEncrypt_LocalIIS,
+                    DateExpiry = DateTime.Now.AddDays(60 - 5 * i),
+                    RequestConfig = new CertRequestConfig()
+                    {
+                        ChallengeType = ACMESharpCompat.ACMESharpUtils.CHALLENGE_TYPE_SNI,
+                        PerformAutomatedCertBinding = true,
+                        PreRequestPowerShellScript = @"c:\inetpub\scripts\pre-req-script.ps1",
+                        PostRequestPowerShellScript = @"c:\inetpub\scripts\post-req-script.ps1",
+                        WebhookTrigger = Webhook.ON_SUCCESS,
+                        WebhookUrl = "https://certifytheweb.com/api/notify?domain=$domain&key=123456",
+                        WebhookMethod = Webhook.METHOD_POST
+                    },
+                    CertificatePath = @"C:\ProgramData\ACMESharp\sysVault\99-ASSET\cert_ident1a2b3c4d-all.pfx"
+                };
+                site.DomainOptions.Add(new DomainOption()
+                {
+                    Domain = site.Name,
+                    IsPrimaryDomain = true,
+                    IsSelected = true
+                });
+                // add lots of mock domains
+                for (int j = 1; j <= 20; j++)
+                {
+                    site.DomainOptions.Add(new DomainOption()
+                    {
+                        Domain = $"www{j}.{site.Name}",
+                        IsSelected = j <= 3
+                    });
+                }
+                ManagedSites.Add(site);
+            }
+        }
+
+        private string MockDataStore;
+
+        public override void LoadSettings()
+        {
+            var mockSites = JsonConvert.DeserializeObject<List<ManagedSite>>(MockDataStore);
+            foreach (var site in mockSites) site.IsChanged = false;
+            ManagedSites = new ObservableCollection<ManagedSite>(mockSites);
+            ImportedManagedSites = new ObservableCollection<ManagedSite>();
+        }
+
+        public override void SaveSettings()
+        {
+            MockDataStore = JsonConvert.SerializeObject(ManagedSites);
+            foreach (var site in ManagedSites) site.IsChanged = false;
+            ManagedSites = new ObservableCollection<ManagedSite>(ManagedSites);
+        }
+
+        public override List<SiteBindingItem> WebSiteList => 
+            Enumerable.Range(1, 20).Select(i => new SiteBindingItem()
+            {
+                SiteId = i.ToString(),
+                SiteName = $"Website {i}",
+                PhysicalPath = $@"c:\inetpub\wwwroot\website{i}",
+                IsEnabled = true
+            })
+            .ToList();
+
+        public override bool IsIISAvailable => true;
+        public override Version IISVersion => new Version(10,0);
+        public override bool HasRegisteredContacts => true;
+
+        protected override IEnumerable<DomainOption> GetDomainOptionsFromSite(string siteId)
+        {
+            return Enumerable.Range(1, 50).Select(i => new DomainOption()
+            {
+                Domain = $"www{i}.domain.example.org",
+                IsPrimaryDomain = i == 1,
+                IsSelected = true
+            });
         }
     }
 }

--- a/src/Certify.UI/Windows/ImportManagedSites.xaml.cs
+++ b/src/Certify.UI/Windows/ImportManagedSites.xaml.cs
@@ -1,16 +1,12 @@
-﻿using System;
+﻿using Certify.Models;
+using Certify.UI.ViewModel;
+using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace Certify.UI.Windows
 {
@@ -19,13 +15,7 @@ namespace Certify.UI.Windows
     /// </summary>
     public partial class ImportManagedSites
     {
-        protected Certify.UI.ViewModel.AppModel MainViewModel
-        {
-            get
-            {
-                return ViewModel.AppModel.AppViewModel;
-            }
-        }
+        protected AppModel MainViewModel { get => AppModel.AppViewModel; }
 
         public ImportManagedSites()
         {
@@ -36,9 +26,9 @@ namespace Certify.UI.Windows
 
         private void ButtonPerformImport(object sender, RoutedEventArgs e)
         {
-            this.MainViewModel.ManagedSites = new System.Collections.ObjectModel.ObservableCollection<Models.ManagedSite>(this.MainViewModel.ImportedManagedSites);
+            MainViewModel.ManagedSites = new ObservableCollection<ManagedSite>(MainViewModel.ImportedManagedSites);
 
-            MainViewModel.SaveSettings(null);
+            MainViewModel.SaveSettings();
             this.Close();
         }
 

--- a/src/Certify.UI/Windows/ImportManagedSites.xaml.cs
+++ b/src/Certify.UI/Windows/ImportManagedSites.xaml.cs
@@ -38,7 +38,6 @@ namespace Certify.UI.Windows
         {
             this.MainViewModel.ManagedSites = new System.Collections.ObjectModel.ObservableCollection<Models.ManagedSite>(this.MainViewModel.ImportedManagedSites);
 
-            MainViewModel.MarkAllChangesCompleted();
             MainViewModel.SaveSettings(null);
             this.Close();
         }


### PR DESCRIPTION
* Misc UI updates
  * Keyboard shortcuts (CTRL-F, DEL) on site list
  * Better "discard changes?" detection and handling
  * Fix colors on Server 2008 R2 (or computers with Aero turned off)
  * Made the DesignViewModel usable for testing (uncomment the "new DesignViewModel()" line in AppModel.cs)
  * Fix bug where site list filter stopped working after any settings save
* Core update
  * Centralize change detection on BindableBase objects, automatically bubble up and down IsChanged

I apologize for the size of the PR, but most of the changes (aside from the color fixes) are linked together pretty tightly. I did try to group the changes together into logical commits so they'd be digestable in smaller chunks. 

I'd be a little more careful than usual merging this in without testing, honestly the keyboard navigation stuff was super difficult to get the bugs out of, so although I spent (many!) hours testing it, I wouldn't be surprised if there were a few more in there.

Feel free to pop any questions about this into the dev slack, we can chat async if our timezones aren't overlapping.