### PR TITLE
Better handling for large number of sites

### DIFF
--- a/src/Certify.Core/Certify.Core.csproj
+++ b/src/Certify.Core/Certify.Core.csproj
@@ -137,6 +137,9 @@
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data.SQLite, Version=1.0.106.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Data.SQLite.Core.1.0.106.0\lib\net45\System.Data.SQLite.dll</HintPath>
+    </Reference>
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
@@ -291,7 +294,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets'))" />
+    <Error Condition="!Exists('..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets'))" />
   </Target>
+  <Import Project="..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets" Condition="Exists('..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Certify.Core/Management/Util.cs
+++ b/src/Certify.Core/Management/Util.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Certify.Models;
 using Microsoft.ApplicationInsights;
 using System.Net;
+using System.IO;
 
 namespace Certify.Management
 {
@@ -19,12 +20,18 @@ namespace Certify.Management
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
         }
 
-        public static string GetAppDataFolder()
+        public static string GetAppDataFolder(string subFolder = null)
         {
-            var path = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + "\\" + APPDATASUBFOLDER;
-            if (!System.IO.Directory.Exists(path))
+            var parts = new List<string>()
             {
-                System.IO.Directory.CreateDirectory(path);
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                APPDATASUBFOLDER
+            };
+            if (subFolder != null) parts.Add(subFolder);
+            var path = Path.Combine(parts.ToArray());
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
             }
             return path;
         }

--- a/src/Certify.Core/Models/BindableBase.cs
+++ b/src/Certify.Core/Models/BindableBase.cs
@@ -95,7 +95,7 @@ namespace Certify.Models
         /// <summary>
         /// True if a property has been changed on the model since IsChanged was last set to false 
         /// </summary>
-        [JsonIgnore] // don't serialize this property to saved settings
+        [JsonIgnore] // don't deserialize this property from legacy saved settings
         public bool IsChanged
         {
             get { return isChanged; }

--- a/src/Certify.Core/Models/ManagedItem.cs
+++ b/src/Certify.Core/Models/ManagedItem.cs
@@ -1,4 +1,5 @@
 using Certify.Utils;
+using Newtonsoft.Json;
 using System;
 using System.Collections.ObjectModel;
 using System.Text;
@@ -62,6 +63,9 @@ namespace Certify.Models
         {
             return $"[{Id ?? "null"}]: \"{Name}\"";
         }
+
+        [JsonIgnore]
+        public bool Deleted { get; set; } // do not serialize to settings
     }
 
     public class ManagedSite : ManagedItem

--- a/src/Certify.Core/packages.config
+++ b/src/Certify.Core/packages.config
@@ -19,6 +19,7 @@
   <package id="System.Composition.Hosting" version="1.1.0" targetFramework="net45" />
   <package id="System.Composition.Runtime" version="1.1.0" targetFramework="net45" />
   <package id="System.Composition.TypedParts" version="1.1.0" targetFramework="net45" />
+  <package id="System.Data.SQLite.Core" version="1.0.106.0" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net45" />
   <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net45" />
   <package id="System.Net.Http" version="4.3.3" targetFramework="net45" />

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj
@@ -46,6 +46,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data.SQLite, Version=1.0.106.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Data.SQLite.Core.1.0.106.0\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
@@ -59,7 +62,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Certify.Core\Certify.Core.csproj">
@@ -75,6 +80,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net46\System.Data.SQLite.Core.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net46\System.Data.SQLite.Core.targets')" />
 </Project>

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/ManagedSiteTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/ManagedSiteTests.cs
@@ -16,7 +16,7 @@ namespace Certify.Core.Tests.Unit
             managedSiteSettings.DeleteAllManagedSites();
             managedSiteSettings.StoreSettings();
 
-            var numTestManagedSites = 10000;
+            var numTestManagedSites = 100000;
             var numSANsPerSite = 2;
 
             for (var i = 0; i < numTestManagedSites; i++)

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/packages.config
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net461" />
+  <package id="System.Data.SQLite.Core" version="1.0.106.0" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/src/Certify.UI/Certify.UI.csproj
+++ b/src/Certify.UI/Certify.UI.csproj
@@ -83,6 +83,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.SQLite, Version=1.0.106.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Data.SQLite.Core.1.0.106.0\lib\net45\System.Data.SQLite.dll</HintPath>
+    </Reference>
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
@@ -232,7 +235,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\SR.es-ES.resx">
-     <DependentUpon>SR.resx</DependentUpon>
+      <DependentUpon>SR.resx</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\SR.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
@@ -291,5 +294,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Fody.2.1.2\build\netstandard1.0\Fody.targets'))" />
+    <Error Condition="!Exists('..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets'))" />
   </Target>
+  <Import Project="..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets" Condition="Exists('..\..\packages\System.Data.SQLite.Core.1.0.106.0\build\net45\System.Data.SQLite.Core.targets')" />
 </Project>

--- a/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
+++ b/src/Certify.UI/Controls/ManagedItemSettings.xaml.cs
@@ -156,7 +156,7 @@ namespace Certify.UI.Controls
         private void Button_Delete(object sender, RoutedEventArgs e)
         {
             MainViewModel.DeleteManagedSite(MainViewModel.SelectedItem);
-            if (MainViewModel.ManagedSites.Count == 0 || MainViewModel.SelectedItem.Id == null)
+            if (MainViewModel.SelectedItem?.Id == null)
             {
                 MainViewModel.SelectedItem = MainViewModel.ManagedSites.FirstOrDefault();
             }

--- a/src/Certify.UI/Controls/ManagedSites.xaml
+++ b/src/Certify.UI/Controls/ManagedSites.xaml
@@ -35,7 +35,15 @@
                 <RowDefinition Height="*"></RowDefinition>
             </Grid.RowDefinitions>
             <TextBox Grid.Row="0" Name="txtFilter" TextChanged="TxtFilter_TextChanged" PreviewKeyDown="TxtFilter_PreviewKeyDown" Controls:TextBoxHelper.Watermark="{x:Static res:SR.ManagedSites_Filter}" Controls:TextBoxHelper.ClearTextButton="True"></TextBox>
-            <ListView Grid.Row="1" Name="lvManagedSites" ItemsSource="{Binding ManagedSites}" SelectedItem="{Binding SelectedItem, Mode=OneWay}" SelectionChanged="lvManagedSites_SelectionChanged" SelectionMode="Single">
+            <ListView Grid.Row="1" Name="lvManagedSites"
+                      ItemsSource="{Binding ManagedSites}" 
+                      SelectedItem="{Binding SelectedItem, Mode=OneWay}" 
+                      SelectionChanged="lvManagedSites_SelectionChanged" 
+                      SelectionMode="Single"
+                      ScrollViewer.CanContentScroll="True"
+                      VirtualizingPanel.IsVirtualizing="True"
+                      ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ScrollViewer.HorizontalScrollBarVisibility="Auto">
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
                         <EventSetter Event="PreviewMouseLeftButtonDown" Handler="ListViewItem_InteractionEvent"/>

--- a/src/Certify.UI/ViewModel/AppModel.cs
+++ b/src/Certify.UI/ViewModel/AppModel.cs
@@ -317,6 +317,10 @@ namespace Certify.UI.ViewModel
         public virtual void SaveSettings()
         {
             certifyManager.SaveManagedSites(ManagedSites.ToList());
+            foreach (var site in ManagedSites.Where(s => s.Deleted).ToList())
+            {
+                ManagedSites.Remove(site);
+            }
             ManagedSites = new ObservableCollection<ManagedSite>(ManagedSites);
         }
 
@@ -399,7 +403,7 @@ namespace Certify.UI.ViewModel
             {
                 if (MessageBox.Show(SR.ManagedItemSettings_ConfirmDelete, SR.ConfirmDelete, MessageBoxButtons.OKCancel, MessageBoxIcon.Warning)==DialogResult.OK)
                 {
-                    ManagedSites.Remove(existing);
+                    existing.Deleted = true;
                     SaveSettings();
                 }
             }

--- a/src/Certify.UI/packages.config
+++ b/src/Certify.UI/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="PropertyChanged.Fody" version="2.1.4" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Data.SQLite.Core" version="1.0.106.0" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Optimized ItemManager for large numbers of sites, changed test back to 100K sites. I think test is actually more stressful than the UI due to the way it loads the sites one by one rather than in bulk. I was able to load the test settings file from #177 in the UI pretty quickly and navigate around without any UI delay with this optimization.