### PR TITLE
Fix TLS-SNI local testing

### DIFF
--- a/src/Certify.Core/Certify.Core.csproj
+++ b/src/Certify.Core/Certify.Core.csproj
@@ -211,6 +211,7 @@
     <Compile Include="Resources.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="Utils\SRDescription.cs" />
+    <Compile Include="Utils\X509ExtensionUtilities.cs" />
     <EmbeddedResource Include="CoreSR.es-ES.resx">
       <DependentUpon>CoreSR.resx</DependentUpon>
     </EmbeddedResource>

--- a/src/Certify.Core/Management/CertificateManager.cs
+++ b/src/Certify.Core/Management/CertificateManager.cs
@@ -1,4 +1,5 @@
-﻿using Org.BouncyCastle.Asn1;
+﻿using Certify.Utils;
+using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
@@ -9,7 +10,6 @@ using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Utilities;
 using Org.BouncyCastle.X509;
-using Org.BouncyCastle.X509.Extension;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Certify.Core/Utils/X509ExtensionUtilities.cs
+++ b/src/Certify.Core/Utils/X509ExtensionUtilities.cs
@@ -1,0 +1,98 @@
+﻿using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Security.Certificates;
+using Org.BouncyCastle.X509;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Certify.Utils
+{
+    // from https://github.com/bcgit/bc-csharp/blob/b19e68a517e56ef08cd2e50df4dcb8a96ddbe507/crypto/src/x509/extension/X509ExtensionUtil.cs
+    // incorporates this bugfix commit from 12/28/2016:
+    // https://github.com/bcgit/bc-csharp/commit/96e500fd17aac287d0682aaf58c7f1f4341e1fd6,
+    // which was added after the 1.8.1 release. This code should be removed after the next BouncyCastle update.
+    public class X509ExtensionUtilities
+    {
+        public static Asn1Object FromExtensionValue(
+            Asn1OctetString extensionValue)
+        {
+            return Asn1Object.FromByteArray(extensionValue.GetOctets());
+        }
+
+        public static ICollection GetIssuerAlternativeNames(
+            X509Certificate cert)
+        {
+            Asn1OctetString extVal = cert.GetExtensionValue(X509Extensions.IssuerAlternativeName);
+
+            return GetAlternativeName(extVal);
+        }
+
+        public static ICollection GetSubjectAlternativeNames(
+            X509Certificate cert)
+        {
+            Asn1OctetString extVal = cert.GetExtensionValue(X509Extensions.SubjectAlternativeName);
+
+            return GetAlternativeName(extVal);
+        }
+
+        private static ICollection GetAlternativeName(
+            Asn1OctetString extVal)
+        {
+            IList temp = new ArrayList(); //Platform.CreateArrayList();
+
+            if (extVal != null)
+            {
+                try
+                {
+                    Asn1Sequence seq = DerSequence.GetInstance(FromExtensionValue(extVal));
+
+                    foreach (Asn1Encodable primName in seq)
+                    {
+                        IList list = new ArrayList(); //Platform.CreateArrayList();
+                        GeneralName genName = GeneralName.GetInstance(primName);
+
+                        list.Add(genName.TagNo);
+
+                        switch (genName.TagNo)
+                        {
+                            case GeneralName.EdiPartyName:
+                            case GeneralName.X400Address:
+                            case GeneralName.OtherName:
+                                list.Add(genName.Name.ToAsn1Object());
+                                break;
+                            case GeneralName.DirectoryName:
+                                list.Add(X509Name.GetInstance(genName.Name).ToString());
+                                break;
+                            case GeneralName.DnsName:
+                            case GeneralName.Rfc822Name:
+                            case GeneralName.UniformResourceIdentifier:
+                                list.Add(((IAsn1String)genName.Name).GetString());
+                                break;
+                            case GeneralName.RegisteredID:
+                                list.Add(DerObjectIdentifier.GetInstance(genName.Name).Id);
+                                break;
+                            case GeneralName.IPAddress:
+                                list.Add(DerOctetString.GetInstance(genName.Name).GetOctets());
+                                break;
+                            default:
+                                throw new IOException("Bad tag number: " + genName.TagNo);
+                        }
+
+                        temp.Add(list);
+                    }
+                }
+                catch (Exception e)
+                {
+                    throw new CertificateParsingException(e.Message);
+                }
+            }
+
+            return temp;
+        }
+    }
+}


### PR DESCRIPTION
I noticed that my site using tls-sni-01 challenge started failing with the most recent code (Slack webhook notifications FTW!). After some debugging I came to the unexpected conclusion that there was a bug in the BouncyCastle library code, which it ends up has been fixed in the source (https://github.com/bcgit/bc-csharp/commit/96e500fd17aac287d0682aaf58c7f1f4341e1fd6) but has not been incorporated into a release yet. 

I have no idea why this was working before, none of the related code on our side has changed. Not sure if my test environment changed somehow (Windows Update?) or there was some other upstream change, since if it was failing on parsing the certificate SAN for verification, it should never have worked. Anyway, this fixes the problem so my domain validation works again.

I got most of the way through fixing the VaultManager per-site logging (which I used to debug this problem) before I remembered about the work going on in the localservice branch. I might scrap that work since there probably would be more work merging it in than me just waiting till the dust settles a bit on the localservice branch to make the change on that branch instead.