### PR TITLE
added support for saving and restoring UI app window size and position

### DIFF
--- a/src/Certify.UI/Certify.UI.csproj
+++ b/src/Certify.UI/Certify.UI.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Controls\QuickStart.xaml.cs">
       <DependentUpon>QuickStart.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Settings\UISettings.cs" />
     <Compile Include="Utils\CSRAlgCheckedConverter.cs" />
     <Compile Include="Utils\NullableDateFormatter.cs" />
     <Compile Include="Utils\ExpiryDateConverter.cs" />

--- a/src/Certify.UI/MainWindow.xaml.cs
+++ b/src/Certify.UI/MainWindow.xaml.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using Certify.Locales;
+using Certify.UI.Settings;
 using Microsoft.ApplicationInsights;
 using Serilog;
 
@@ -126,6 +128,19 @@ namespace Certify.UI
 
         private async void Window_Loaded(object sender, RoutedEventArgs e)
         {
+            var uiSettingsFilePath = Management.Util.GetAppDataFolder() + "\\ui.json";
+            if (File.Exists(uiSettingsFilePath))
+            {
+                var configData = File.ReadAllText(uiSettingsFilePath);
+                var uiSettings = Newtonsoft.Json.JsonConvert.DeserializeObject<UISettings>(configData);
+
+                Width = uiSettings.Width;
+                Height = uiSettings.Height;
+
+                Left = uiSettings.Left;
+                Top = uiSettings.Top;
+            }
+
             await PerformAppStartupChecks();
         }
 
@@ -290,6 +305,17 @@ namespace Certify.UI
         {
             // allow cancelling exit to save changes
             if (!await _itemViewModel.ConfirmDiscardUnsavedChanges()) e.Cancel = true;
+
+            var uiSettings = new UISettings
+            {
+                Width = Width,
+                Height = Height,
+                Left = Left,
+                Top = Top
+            };
+
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(uiSettings, Newtonsoft.Json.Formatting.Indented);
+            File.WriteAllText(Management.Util.GetAppDataFolder() + "\\ui.json", json);
         }
     }
 }

--- a/src/Certify.UI/Settings/UISettings.cs
+++ b/src/Certify.UI/Settings/UISettings.cs
@@ -1,0 +1,11 @@
+﻿namespace Certify.UI.Settings
+{
+    class UISettings
+    {
+        public double Width { get; set; }
+        public double Height { get; set; }
+
+        public double Left { get; set; }
+        public double Top { get; set; }
+    }
+}


### PR DESCRIPTION
Added support for saving the Certify app window width, height and position when closing the main app window. The settings are stored in a file called ui.json in the program data directory, and the settings are read when the app window is loaded to restore the previous session window size and position.