### PR TITLE
NameCheap DNS provider

### DIFF
--- a/Certify.sln
+++ b/Certify.sln
@@ -69,9 +69,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Certify.Providers.ACMESharp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Certify.SharedUtils", "src\Certify.SharedUtils\Certify.SharedUtils.csproj", "{BAADC03D-4580-4461-9822-D7AC083E6C7B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSDNS", "src\Certify.Providers\DNS\MSDNS\MSDNS.csproj", "{9C095EB3-3B0A-44C9-9728-6118E7C5B934}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSDNS", "src\Certify.Providers\DNS\MSDNS\MSDNS.csproj", "{9C095EB3-3B0A-44C9-9728-6118E7C5B934}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AcmeDns", "src\Certify.Providers\DNS\AcmeDns\AcmeDns\AcmeDns.csproj", "{4FE830FC-5B13-4A27-AF18-8E135C0314F2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AcmeDns", "src\Certify.Providers\DNS\AcmeDns\AcmeDns\AcmeDns.csproj", "{4FE830FC-5B13-4A27-AF18-8E135C0314F2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NameCheap", "src\Certify.Providers\DNS\NameCheap\NameCheap.csproj", "{E537F4ED-E129-487A-BDAB-59BB430A603A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -281,6 +283,14 @@ Global
 		{4FE830FC-5B13-4A27-AF18-8E135C0314F2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4FE830FC-5B13-4A27-AF18-8E135C0314F2}.Release|x64.ActiveCfg = Release|Any CPU
 		{4FE830FC-5B13-4A27-AF18-8E135C0314F2}.Release|x64.Build.0 = Release|Any CPU
+		{E537F4ED-E129-487A-BDAB-59BB430A603A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E537F4ED-E129-487A-BDAB-59BB430A603A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E537F4ED-E129-487A-BDAB-59BB430A603A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E537F4ED-E129-487A-BDAB-59BB430A603A}.Debug|x64.Build.0 = Debug|Any CPU
+		{E537F4ED-E129-487A-BDAB-59BB430A603A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E537F4ED-E129-487A-BDAB-59BB430A603A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E537F4ED-E129-487A-BDAB-59BB430A603A}.Release|x64.ActiveCfg = Release|Any CPU
+		{E537F4ED-E129-487A-BDAB-59BB430A603A}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -304,6 +314,7 @@ Global
 		{8E1E6901-ABB9-47DF-B715-BADB229E6909} = {D2D146B6-E84E-4901-AAA9-DE3E199FD4EF}
 		{9C095EB3-3B0A-44C9-9728-6118E7C5B934} = {3BE55972-6A8A-454E-9C79-DBDBC9ADAB18}
 		{4FE830FC-5B13-4A27-AF18-8E135C0314F2} = {3BE55972-6A8A-454E-9C79-DBDBC9ADAB18}
+		{E537F4ED-E129-487A-BDAB-59BB430A603A} = {3BE55972-6A8A-454E-9C79-DBDBC9ADAB18}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D27296BB-12D3-44A5-B5A2-B79EB1AB223D}

--- a/src/Certify.Core/Certify.Core.csproj
+++ b/src/Certify.Core/Certify.Core.csproj
@@ -78,6 +78,7 @@
     <ProjectReference Include="..\Certify.Providers\DNS\MSDNS\MSDNS.csproj" />
     <ProjectReference Include="..\Certify.Providers\DNS\OVH\OVH.csproj" />
     <ProjectReference Include="..\Certify.Providers\DNS\SimpleDNSPlus\SimpleDNSPlus.csproj" />
+    <ProjectReference Include="..\Certify.Providers\DNS\NameCheap\NameCheap.csproj" />
     <ProjectReference Include="..\Certify.Shared\Certify.Shared.csproj" />
   </ItemGroup>
   

--- a/src/Certify.Core/Management/Challenges/ChallengeProviders.cs
+++ b/src/Certify.Core/Management/Challenges/ChallengeProviders.cs
@@ -14,6 +14,7 @@ using Certify.Providers.DNS.Cloudflare;
 using Certify.Providers.DNS.DnsMadeEasy;
 using Certify.Providers.DNS.GoDaddy;
 using Certify.Providers.DNS.MSDNS;
+using Certify.Providers.DNS.NameCheap;
 using Certify.Providers.DNS.OVH;
 using Certify.Providers.DNS.SimpleDNSPlus;
 
@@ -97,6 +98,10 @@ namespace Certify.Core.Management.Challenges
                 else if (providerDefinition.Id == DnsProviderAcmeDns.Definition.Id)
                 {
                     dnsAPIProvider = new DnsProviderAcmeDns(credentials, parameters, Util.GetAppDataFolder());
+                }
+                else if(providerDefinition.Id == DnsProviderNameCheap.Definition.Id)
+                {
+                    dnsAPIProvider = new DnsProviderNameCheap(credentials);
                 }
             }
             else if (providerDefinition.HandlerType == Models.Config.ChallengeHandlerType.MANUAL)

--- a/src/Certify.Core/Management/Challenges/ChallengeProviders.cs
+++ b/src/Certify.Core/Management/Challenges/ChallengeProviders.cs
@@ -158,7 +158,8 @@ namespace Certify.Core.Management.Challenges
                 Providers.DNS.DnsMadeEasy.DnsProviderDnsMadeEasy.Definition,
                 Providers.DNS.OVH.DnsProviderOvh.Definition,
                 Providers.DNS.Aliyun.DnsProviderAliyun.Definition,
-                Providers.DNS.AcmeDns.DnsProviderAcmeDns.Definition
+                Providers.DNS.AcmeDns.DnsProviderAcmeDns.Definition,
+                Providers.DNS.NameCheap.DnsProviderNameCheap.Definition
             };
 
             try

--- a/src/Certify.Providers/DNS/NameCheap/DnsProviderNameCheap.cs
+++ b/src/Certify.Providers/DNS/NameCheap/DnsProviderNameCheap.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web;
+using System.Xml.Linq;
+using Certify.Models;
+using Certify.Models.Config;
+using Certify.Models.Providers;
+
+// ReSharper disable once CheckNamespace
+namespace Certify.Providers.DNS.NameCheap
+{
+    public class DnsProviderNameCheap: IDnsProvider
+    {
+        public DnsProviderNameCheap(Dictionary<string, string> credentials)
+        {
+            _apiUser = credentials[PARAM_API_USER];
+            _apiKey = credentials[PARAM_API_KEY];
+            _ip = credentials[PARAM_IP];
+
+            _http = new HttpClient();
+        }
+
+        private readonly string _apiUser;
+        private readonly string _apiKey;
+        private readonly string _ip;
+
+        private readonly HttpClient _http;
+
+        private ILog _log;
+
+        #region Definition
+
+        private const string PARAM_API_USER = "apiuser";
+        private const string PARAM_API_KEY = "apikey";
+        private const string PARAM_IP = "ip";
+
+        private const string API_URL = "https://api.sandbox.namecheap.com/xml.response";
+        private const int BATCH_SIZE = 100;
+
+        private static XNamespace _ns;
+
+        static DnsProviderNameCheap()
+        {
+            Definition = new ProviderDefinition
+            {
+                Id = "DNS01.API.NameCheap",
+                Title = "NameCheap DNS API",
+                Description = "Validates via NameCheap APIs",
+                HelpUrl = "https://www.namecheap.com/",
+                PropagationDelaySeconds = 60,
+                ProviderParameters = new List<ProviderParameter>
+                {
+                    new ProviderParameter { Key = PARAM_API_USER, Name = "API User", IsRequired = true, IsPassword = false },
+                    new ProviderParameter { Key = PARAM_API_KEY, Name = "API Key", IsRequired = true, IsPassword = true },
+                    new ProviderParameter { Key = PARAM_IP, Name = "Your IP", Description = "IP Address of the server that sends requests to NameCheap API", IsRequired = true, IsPassword = false }
+                },
+                ChallengeType = SupportedChallengeTypes.CHALLENGE_TYPE_DNS,
+                Config = "Provider=Certify.Providers.DNS.NameCheap",
+                HandlerType = ChallengeHandlerType.INTERNAL
+            };
+
+            _ns = XNamespace.Get("http://api.namecheap.com/xml.response");
+        }
+
+        /// <summary>
+        /// The definition properties for NameCheap.
+        /// </summary>
+        public static ProviderDefinition Definition { get; private set; }
+
+        public int PropagationDelaySeconds => Definition.PropagationDelaySeconds;
+        public string ProviderId => Definition.Id;
+        public string ProviderTitle => Definition.Title;
+        public string ProviderDescription => Definition.Description;
+        public string ProviderHelpUrl => Definition.HelpUrl;
+        public List<ProviderParameter> ProviderParameters => Definition.ProviderParameters;
+
+        #endregion
+
+        /// <summary>
+        /// Initializes the provider.
+        /// </summary>
+        public Task<bool> InitProvider(ILog log = null)
+        {
+            _log = log;
+            return Task.FromResult(true);
+        }
+
+        /// <summary>
+        /// Tests connection to the service.
+        /// </summary>
+        public async Task<ActionResult> Test()
+        {
+            try
+            {
+                var zones = await GetZonesBatchAsync(1);
+                if (zones?.Any() == true)
+                    return new ActionResult {IsSuccess = true, Message = "Test completed."};
+
+                return new ActionResult {IsSuccess = true, Message = "Test completed, but no zones returned."};
+            }
+            catch (Exception ex)
+            {
+                return new ActionResult {IsSuccess = false, Message = "Test failed: " + ex.Message };
+            }
+        }
+
+        /// <summary>
+        /// Adds a DNS record to the list.
+        /// </summary>
+        public async Task<ActionResult> CreateRecord(DnsRecord request)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Removes a DNS record from the list.
+        /// </summary>
+        public async Task<ActionResult> DeleteRecord(DnsRecord request)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns the list of available zones.
+        /// </summary>
+        public async Task<List<DnsZone>> GetZones()
+        {
+            var result = new List<DnsZone>();
+            var page = 1;
+
+            while (true)
+            {
+                var zoneBatch = await GetZonesBatchAsync(page);
+                result.AddRange(zoneBatch);
+                page++;
+
+                if (zoneBatch.Count < BATCH_SIZE)
+                    break;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a batch of zones
+        /// </summary>
+        private async Task<IReadOnlyList<DnsZone>> GetZonesBatchAsync(int page)
+        {
+            try
+            {
+                var xmlResponse = await InvokeGetApiAsync("domains.getList", new Dictionary<string, string>
+                {
+                    ["Page"] = page.ToString(),
+                    ["PageSize"] = BATCH_SIZE.ToString(),
+                    ["SortBy"] = "NAME"
+                });
+
+                return xmlResponse.Element(_ns + "CommandResponse")
+                                  .Element(_ns + "DomainGetListResult")
+                                  .Elements(_ns + "Domain")
+                                  .Where(x => x.Attribute("IsExpired")?.Value == "false"
+                                              && x.Attribute("IsLocked")?.Value == "false"
+                                              && x.Attribute("IsOurDNS")?.Value == "true")
+                                  .Select(x => x.Attribute("Name").Value)
+                                  .Select(x => new DnsZone
+                                  {
+                                      Name = x,
+                                      ZoneId = x
+                                  })
+                                  .ToList();
+            }
+            catch (Exception exp)
+            {
+                _log.Error(exp, "Failed to get a batch of domain zones.");
+
+                return new DnsZone[0];
+            }
+        }
+
+        #region Private helpers
+
+        /// <summary>
+        /// Invokes the API method via a GET request, returning the XML results.
+        /// </summary>
+        private async Task<XElement> InvokeGetApiAsync(string command, Dictionary<string, string> args = null)
+        {
+            string Encode(string arg) => HttpUtility.UrlEncode(arg);
+
+            args = WithDefaultArgs(command, args);
+            var url = API_URL + "?" + string.Join("&", args.Select(kvp => Encode(kvp.Key) + "=" + Encode(kvp.Value)));
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            return await InvokeApiAsync(request);
+        }
+
+        /// <summary>
+        /// Invokes the API method.
+        /// </summary>
+        private async Task<XElement> InvokeApiAsync(HttpRequestMessage request)
+        {
+            var response = await _http.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+                throw new Exception($"NameCheap API method {request.RequestUri} returned HTTP Code {response.StatusCode}");
+
+            XElement xml;
+            try
+            {
+                xml = XElement.Parse(content);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"NameCheap API method {request.RequestUri} returned invalid XML response:\n{content}", ex);
+            }
+
+            if(xml.Attribute("Status")?.Value.ToLower() != "ok")
+                throw new Exception($"NameCheap API method {request.RequestUri} returned an error status '{xml.Attribute("Status")?.Value}':\n{content}");
+
+            return xml;
+        }
+
+        /// <summary>
+        /// Populates the argument list with default args.
+        /// </summary>
+        private Dictionary<string, string> WithDefaultArgs(string command, Dictionary<string, string> args = null)
+        {
+            if(args == null)
+                args = new Dictionary<string, string>();
+
+            args.Add("ApiUser", _apiUser);
+            args.Add("ApiKey", _apiKey);
+            args.Add("UserName", _apiUser);
+            args.Add("Command", "namecheap." + command);
+            args.Add("ClientIp", _ip);
+
+            return args;
+        }
+
+        #endregion
+    }
+}

--- a/src/Certify.Providers/DNS/NameCheap/NameCheap.csproj
+++ b/src/Certify.Providers/DNS/NameCheap/NameCheap.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Certify.DNS.NameCheap</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Certify.Models\Certify.Models.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Certify.Providers/DNS/NameCheap/NameCheapHostRecord.cs
+++ b/src/Certify.Providers/DNS/NameCheap/NameCheapHostRecord.cs
@@ -1,4 +1,5 @@
-﻿namespace NameCheap
+﻿// ReSharper disable once CheckNamespace
+namespace Certify.Providers.DNS.NameCheap
 {
     /// <summary>
     /// Information about a single host.

--- a/src/Certify.Providers/DNS/NameCheap/NameCheapHostRecord.cs
+++ b/src/Certify.Providers/DNS/NameCheap/NameCheapHostRecord.cs
@@ -1,0 +1,15 @@
+﻿namespace NameCheap
+{
+    /// <summary>
+    /// Information about a single host.
+    /// </summary>
+    public class NameCheapHostRecord
+    {
+        public int HostId { get; set; }
+        public string Name { get; set; }
+        public string Type { get; set; }
+        public string Address { get; set; }
+        public int MxPref { get; set; }
+        public int Ttl { get; set; }
+    }
+}

--- a/src/Certify.Providers/DNS/NameCheap/XmlExtensions.cs
+++ b/src/Certify.Providers/DNS/NameCheap/XmlExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Xml.Linq;
 
-namespace NameCheap
+// ReSharper disable once CheckNamespace
+namespace Certify.Providers.DNS.NameCheap
 {
     public static class XmlExtensions
     {

--- a/src/Certify.Providers/DNS/NameCheap/XmlExtensions.cs
+++ b/src/Certify.Providers/DNS/NameCheap/XmlExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Xml.Linq;
+
+namespace NameCheap
+{
+    public static class XmlExtensions
+    {
+        /// <summary>
+        /// Returns the parsed value of an attribute.
+        /// </summary>
+        public static T Attr<T>(this XElement xml, string attrName)
+        {
+            try
+            {
+                return (T) Convert.ChangeType(xml.Attribute(attrName)?.Value, typeof(T));
+            }
+            catch
+            {
+                return default(T);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #376.

Tricky things to know about NameCheap API:

* API is only available if you have $50 on your account or have bought $50 worth of services in the last 2 years
* The "API activation takes up to 2 business days" claim is baloney, they can do it immediately if you contact support and will likely ignore your request altogether if you don't.
* You need to manually add your server's IP to a whitelist before you can send API requests. If you have a dynamic IP, well, oops, you're out of luck.
* The API _also_ requires sending current client IP with every single request (hence the "IP" field in NameCheap credentials).

I didn't add anything to the documentation project yet. Can open another pull request there if required.