### PR TITLE
Use PluginManager for DNS providers and allow adding DNS and deployment task providers without recompiling

### DIFF
--- a/src/Certify.Core/Certify.Core.csproj
+++ b/src/Certify.Core/Certify.Core.csproj
@@ -69,18 +69,6 @@
     <ProjectReference Include="..\Certify.Locales\Certify.Locales.csproj" />
     <ProjectReference Include="..\Certify.Models\Certify.Models.csproj" />
     <ProjectReference Include="..\Certify.Providers\ACME\Certes\Certify.Providers.ACME.Certes.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\AcmeDns\AcmeDns\AcmeDns.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\Aliyun\Aliyun.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\AWSRoute53\AWSRoute53.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\Azure\Azure.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\Cloudflare\Cloudflare.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\DnsMadeEasy\DnsMadeEasy.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\GoDaddy\GoDaddy.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\MSDNS\MSDNS.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\OVH\OVH.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\SimpleDNSPlus\SimpleDNSPlus.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\NameCheap\NameCheap.csproj" />
-    <ProjectReference Include="..\Certify.Providers\DNS\TransIP\TransIP.csproj" />
     <ProjectReference Include="..\Certify.Shared.Compat\Certify.Shared.Compat.csproj" />
     <ProjectReference Include="..\Certify.Shared\Certify.Shared.Core.csproj" />
   </ItemGroup>

--- a/src/Certify.Core/Management/CertifyManager/CertifyManager.cs
+++ b/src/Certify.Core/Management/CertifyManager/CertifyManager.cs
@@ -75,7 +75,7 @@ namespace Certify.Management
             _progressResults = new ObservableCollection<RequestProgressState>();
 
             _pluginManager = new PluginManager();
-            _pluginManager.LoadPlugins(new List<string> { "Licensing", "DashboardClient", "DeploymentTasks", "CertificateManagers" });
+            _pluginManager.LoadPlugins(new List<string> { "Licensing", "DashboardClient", "DeploymentTasks", "CertificateManagers", "ChallengeProviders" });
 
 
             // load core CAs and custom CAs

--- a/src/Certify.Core/Management/Challenges/ChallengeDiagnostics.cs
+++ b/src/Certify.Core/Management/Challenges/ChallengeDiagnostics.cs
@@ -221,7 +221,8 @@ namespace Certify.Core.Management.Challenges
                     {
                         var recordName = $"_acme-challenge-test.{domain}".Replace("*.", "");
 
-                        if (challengeConfig.ChallengeProvider == Certify.Providers.DNS.AcmeDns.DnsProviderAcmeDns.Definition.Id)
+                        // ISSUE: dependency on changing behavior for a specific plugin
+                        if (challengeConfig.ChallengeProvider == "DNS01.API.AcmeDns")
                         {
                             // use real cname to avoid having to setup different records
                             recordName = $"_acme-challenge.{domain}".Replace("*.", "");

--- a/src/Certify.Core/Management/Challenges/DNS/DnsProviderLibcloud.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsProviderLibcloud.cs
@@ -111,7 +111,7 @@ namespace Certify.Core.Management.Challenges
 
         public Task<List<DnsZone>> GetZones() => throw new NotImplementedException();
 
-        public async Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log)
         {
             _log = log;
             return await Task.FromResult(true);

--- a/src/Certify.Core/Management/Challenges/DNS/DnsProviderManual.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsProviderManual.cs
@@ -59,7 +59,7 @@ namespace Certify.Core.Management.Challenges.DNS
 
         Task<List<DnsZone>> IDnsProvider.GetZones() => Task.FromResult(new List<DnsZone>());
 
-        Task<bool> IDnsProvider.InitProvider(Dictionary<string, string> parameters, ILog log)
+        Task<bool> IDnsProvider.InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log)
         {
             _log = log;
 

--- a/src/Certify.Core/Management/Challenges/DNS/DnsProviderScripting.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsProviderScripting.cs
@@ -26,8 +26,8 @@ namespace Certify.Core.Management.Challenges.DNS
 
         List<ProviderParameter> IDnsProvider.ProviderParameters => Definition.ProviderParameters;
 
-        private readonly string _createScriptPath = "";
-        private readonly string _deleteScriptPath = "";
+        private string _createScriptPath = "";
+        private string _deleteScriptPath = "";
         private int? _customPropagationDelay = null;
 
         public static ChallengeProviderDefinition Definition => new ChallengeProviderDefinition
@@ -48,17 +48,8 @@ namespace Certify.Core.Management.Challenges.DNS
             HandlerType = ChallengeHandlerType.CUSTOM_SCRIPT
         };
 
-        public DnsProviderScripting(Dictionary<string, string> parameters)
+        public DnsProviderScripting()
         {
-            if (parameters.ContainsKey("createscriptpath"))
-            {
-                _createScriptPath = parameters["createscriptpath"];
-            }
-
-            if (parameters.ContainsKey("deletescriptpath"))
-            {
-                _deleteScriptPath = parameters["deletescriptpath"];
-            }
         }
 
         public async Task<ActionResult> CreateRecord(DnsRecord request)
@@ -93,10 +84,20 @@ namespace Certify.Core.Management.Challenges.DNS
 
         Task<List<DnsZone>> IDnsProvider.GetZones() => Task.FromResult(new List<DnsZone>());
 
-        Task<bool> IDnsProvider.InitProvider(Dictionary<string, string> parameters, ILog log)
+        Task<bool> IDnsProvider.InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log)
         {
             _log = log;
-            
+
+            if (parameters?.ContainsKey("createscriptpath") == true)
+            {
+                _createScriptPath = parameters["createscriptpath"];
+            }
+
+            if (parameters?.ContainsKey("deletescriptpath") == true)
+            {
+                _deleteScriptPath = parameters["deletescriptpath"];
+            }
+
             if (parameters?.ContainsKey("propagationdelay") == true)
             {
                 if (int.TryParse(parameters["propagationdelay"], out int customPropDelay))

--- a/src/Certify.Models/Plugins/PluginInterfaces.cs
+++ b/src/Certify.Models/Plugins/PluginInterfaces.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Certify.Models.Config;
+using Certify.Models.Providers;
 using Certify.Models.Shared;
 using Certify.Providers.CertificateManagers;
 using Certify.Providers.DeploymentTasks;
@@ -59,5 +60,12 @@ namespace Certify.Models.Plugins
     /// </summary>
     public interface ICertificateManagerProviderPlugin: IProviderPlugin<ICertificateManager, ProviderDefinition>
     {
+    }
+
+    /// <summary>
+    /// Plugins which implement one or more DNS providers implement this interface for dynamic plugin loading
+    /// </summary>
+    public interface IDnsProviderProviderPlugin: IProviderPlugin<IDnsProvider, ChallengeProviderDefinition>
+    { 
     }
 }

--- a/src/Certify.Models/Plugins/PluginInterfaces.cs
+++ b/src/Certify.Models/Plugins/PluginInterfaces.cs
@@ -48,7 +48,7 @@ namespace Certify.Models.Plugins
     }
 
     /// <summary>
-    /// Plugins which implement on or more deployment tasks implement this interface for dynamic plugin loading
+    /// Plugins which implement one or more deployment tasks implement this interface for dynamic plugin loading
     /// </summary>
     public interface IDeploymentTaskProviderPlugin: IProviderPlugin<IDeploymentTaskProvider, DeploymentProviderDefinition>
     {

--- a/src/Certify.Models/Providers/IDnsProvider.cs
+++ b/src/Certify.Models/Providers/IDnsProvider.cs
@@ -32,7 +32,7 @@ namespace Certify.Models.Providers
 
     public interface IDnsProvider
     {
-        Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log = null);
+        Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null);
 
         /// <summary>
         /// Perform a test of credentials, usually by listings DNS zones

--- a/src/Certify.Providers/DNS/AWSRoute53/DnsProviderAWSRoute53.cs
+++ b/src/Certify.Providers/DNS/AWSRoute53/DnsProviderAWSRoute53.cs
@@ -6,11 +6,14 @@ using Amazon.Route53;
 using Amazon.Route53.Model;
 using Certify.Models;
 using Certify.Models.Config;
+using Certify.Models.Plugins;
 using Certify.Models.Providers;
 using Newtonsoft.Json;
 
 namespace Certify.Providers.DNS.AWSRoute53
 {
+    public class DnsProviderAWSRoute53Provider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
+
     public class DnsProviderAWSRoute53 : IDnsProvider
     {
         private AmazonRoute53Client _route53Client;
@@ -49,9 +52,8 @@ namespace Certify.Providers.DNS.AWSRoute53
             HandlerType = ChallengeHandlerType.INTERNAL
         };
 
-        public DnsProviderAWSRoute53(Dictionary<string, string> credentials)
+        public DnsProviderAWSRoute53()
         {
-            _route53Client = new AmazonRoute53Client(credentials["accesskey"], credentials["secretaccesskey"], Amazon.RegionEndpoint.USEast1);
         }
 
         public async Task<ActionResult> Test()
@@ -266,9 +268,11 @@ namespace Certify.Providers.DNS.AWSRoute53
             return results;
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
         {
             _log = log;
+
+            _route53Client = new AmazonRoute53Client(credentials["accesskey"], credentials["secretaccesskey"], Amazon.RegionEndpoint.USEast1);
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {

--- a/src/Certify.Providers/DNS/AcmeDns/AcmeDns/AcmeDns.csproj
+++ b/src/Certify.Providers/DNS/AcmeDns/AcmeDns/AcmeDns.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Certify.Models\Certify.Models.csproj" />
+    <ProjectReference Include="..\..\..\..\Certify.Shared\Certify.Shared.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Certify.Providers/DNS/AcmeDns/AcmeDns/DnsProviderAcmeDns.cs
+++ b/src/Certify.Providers/DNS/AcmeDns/AcmeDns/DnsProviderAcmeDns.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using Certify.Models;
 using Certify.Models.Config;
+using Certify.Models.Plugins;
 using Certify.Models.Providers;
 using Newtonsoft.Json;
 
@@ -22,6 +23,8 @@ namespace Certify.Providers.DNS.AcmeDns
         public string username { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
     }
+
+    public class DnsProviderAcmeDnsProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
 
     public class DnsProviderAcmeDns : IDnsProvider
     {
@@ -73,10 +76,9 @@ namespace Certify.Providers.DNS.AcmeDns
 
         private string _settingsPath { get; set; }
 
-        public DnsProviderAcmeDns(Dictionary<string, string> credentials, Dictionary<string, string> parameters, string settingsPath)
+        public DnsProviderAcmeDns()
         {
-            _parameters = parameters;
-            _settingsPath = settingsPath;
+            _settingsPath = Util.GetAppDataFolder();
 
             _client = new HttpClient();
             _client.DefaultRequestHeaders.Add("User-Agent", "Certify/DnsProviderAcmeDns");
@@ -229,9 +231,10 @@ namespace Certify.Providers.DNS.AcmeDns
             return await Task.FromResult(results);
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
         {
             _log = log;
+            _parameters = parameters;
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {

--- a/src/Certify.Providers/DNS/Aliyun/DnsProviderAliyun.cs
+++ b/src/Certify.Providers/DNS/Aliyun/DnsProviderAliyun.cs
@@ -5,20 +5,25 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Certify.Models;
 using Certify.Models.Config;
+using Certify.Models.Plugins;
 using Certify.Models.Providers;
 using Newtonsoft.Json;
 
 namespace Certify.Providers.DNS.Aliyun
 {
+
+    public class DnsProviderAliyunProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
+
     /// <summary>
     /// Alibaba Cloud DNS API Provider contributed by https://github.com/TkYu
     /// </summary>
+    /// 
     public class DnsProviderAliyun : DnsProviderBase, IDnsProvider
     {
         private ILog _log;
 
-        private readonly string _accessKeyId;
-        private readonly string _accessKeySecret;
+        private string _accessKeyId;
+        private string _accessKeySecret;
 
         private int? _customPropagationDelay = null;
         public int PropagationDelaySeconds => (_customPropagationDelay != null ? (int)_customPropagationDelay : Definition.PropagationDelaySeconds);
@@ -79,11 +84,8 @@ namespace Certify.Providers.DNS.Aliyun
             HandlerType = ChallengeHandlerType.INTERNAL
         };
 
-        public DnsProviderAliyun(Dictionary<string, string> credentials)
-        {
-            _accessKeyId = credentials["accesskeyid"];
-            _accessKeySecret = credentials["accesskeysecret"];
-        }
+        public DnsProviderAliyun()
+        {}
 
         public async Task<ActionResult> Test()
         {
@@ -252,9 +254,11 @@ namespace Certify.Providers.DNS.Aliyun
             return zones;
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
         {
             _log = log;
+            _accessKeyId = credentials["accesskeyid"];
+            _accessKeySecret = credentials["accesskeysecret"];
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {

--- a/src/Certify.Providers/DNS/Azure/DnsProviderAzure.cs
+++ b/src/Certify.Providers/DNS/Azure/DnsProviderAzure.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Certify.Models.Config;
+using Certify.Models.Plugins;
 using Certify.Models.Providers;
 using Microsoft.Azure.Management.Dns;
 using Microsoft.Azure.Management.Dns.Models;
@@ -10,6 +11,8 @@ using Microsoft.Rest.Azure.Authentication;
 
 namespace Certify.Providers.DNS.Azure
 {
+    public class DnsProviderAzureProvider : PluginProviderBase<IDnsProvider,ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
+
     public class DnsProviderAzure : DnsProviderBase, IDnsProvider
     {
         private ILog _log;
@@ -51,9 +54,8 @@ namespace Certify.Providers.DNS.Azure
             HandlerType = ChallengeHandlerType.INTERNAL
         };
 
-        public DnsProviderAzure(Dictionary<string, string> credentials)
+        public DnsProviderAzure()
         {
-            _credentials = credentials;
         }
 
         public async Task<ActionResult> Test()
@@ -78,9 +80,11 @@ namespace Certify.Providers.DNS.Azure
             }
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
         {
             _log = log;
+
+            _credentials = credentials;
 
             // https://docs.microsoft.com/en-us/dotnet/api/overview/azure/dns?view=azure-dotnet
 

--- a/src/Certify.Providers/DNS/DnsMadeEasy/DnsProviderDnsMadeEasy.cs
+++ b/src/Certify.Providers/DNS/DnsMadeEasy/DnsProviderDnsMadeEasy.cs
@@ -6,11 +6,15 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Certify.Models.Config;
+using Certify.Models.Plugins;
 using Certify.Models.Providers;
 using Newtonsoft.Json;
 
 namespace Certify.Providers.DNS.DnsMadeEasy
 {
+
+    public class DnsProviderDnsMadeEasyProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
+
     /// <summary>
     /// API calls based on https://api-docs.dnsmadeeasy.com/
     /// </summary>
@@ -73,10 +77,8 @@ namespace Certify.Providers.DNS.DnsMadeEasy
             HandlerType = ChallengeHandlerType.INTERNAL
         };
 
-        public DnsProviderDnsMadeEasy(Dictionary<string, string> credentials)
+        public DnsProviderDnsMadeEasy()
         {
-            _apiKey = credentials["apikey"];
-            _apiSecret = credentials["apisecret"];
             _httpClient = new HttpClient();
         }
 
@@ -273,9 +275,11 @@ namespace Certify.Providers.DNS.DnsMadeEasy
             }
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
         {
             _log = log;
+            _apiKey = credentials["apikey"];
+            _apiSecret = credentials["apisecret"];
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {

--- a/src/Certify.Providers/DNS/GoDaddy/DnsProviderGoDaddy.cs
+++ b/src/Certify.Providers/DNS/GoDaddy/DnsProviderGoDaddy.cs
@@ -4,14 +4,14 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Certify.Models.Config;
+using Certify.Models.Plugins;
 using Certify.Models.Providers;
 using Newtonsoft.Json;
 
 namespace Certify.Providers.DNS.GoDaddy
 {
-    /// <summary>
-    /// GoDaddy DNS API Provider contributed by https://github.com/alphaz18
-    /// </summary>
+    public class DnsProviderGoDaddyProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
+
     internal class Zone
     {
         public string Domain { get; set; }
@@ -31,12 +31,15 @@ namespace Certify.Providers.DNS.GoDaddy
         public DnsRecord[] Result { get; set; }
     }
 
+    /// <summary>
+    /// GoDaddy DNS API Provider contributed by https://github.com/alphaz18
+    /// </summary>
     public class DnsProviderGoDaddy : DnsProviderBase, IDnsProvider
     {
         private ILog _log;
         private HttpClient _client = new HttpClient();
-        private readonly string _authKey;
-        private readonly string _authSecret;
+        private string _authKey;
+        private string _authSecret;
         private const string _baseUri = "https://api.godaddy.com/v1/";
         private const string _listZonesUri = _baseUri + "domains?limit=1000";
         private const string _createRecordUri = _baseUri + "domains/{0}/records";
@@ -77,10 +80,8 @@ namespace Certify.Providers.DNS.GoDaddy
             HandlerType = ChallengeHandlerType.INTERNAL
         };
 
-        public DnsProviderGoDaddy(Dictionary<string, string> credentials)
+        public DnsProviderGoDaddy()
         {
-            _authKey = credentials["authkey"];
-            _authSecret = credentials["authsecret"];
         }
 
         public async Task<ActionResult> Test()
@@ -300,9 +301,12 @@ namespace Certify.Providers.DNS.GoDaddy
             return zones;
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
         {
             _log = log;
+
+            _authKey = credentials["authkey"];
+            _authSecret = credentials["authsecret"];
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {

--- a/src/Certify.Providers/DNS/NameCheap/DnsProviderNameCheap.cs
+++ b/src/Certify.Providers/DNS/NameCheap/DnsProviderNameCheap.cs
@@ -7,27 +7,25 @@ using System.Web;
 using System.Xml.Linq;
 using Certify.Models;
 using Certify.Models.Config;
+using Certify.Models.Plugins;
 using Certify.Models.Providers;
 
 // ReSharper disable once CheckNamespace
 namespace Certify.Providers.DNS.NameCheap
 {
+    public class DnsProviderNameCheapProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
+
     public class DnsProviderNameCheap : IDnsProvider
     {
-        public DnsProviderNameCheap(Dictionary<string, string> credentials)
+        public DnsProviderNameCheap()
         {
-            _apiUser = credentials[PARAM_API_USER];
-            _apiKey = credentials[PARAM_API_KEY];
-            _ip = credentials[PARAM_IP];
-
-            _http = new HttpClient();
         }
 
-        private readonly string _apiUser;
-        private readonly string _apiKey;
-        private readonly string _ip;
+        private string _apiUser;
+        private string _apiKey;
+        private string _ip;
 
-        private readonly HttpClient _http;
+        private HttpClient _http;
 
         private ILog _log;
 
@@ -87,9 +85,15 @@ namespace Certify.Providers.DNS.NameCheap
         /// <summary>
         /// Initializes the provider.
         /// </summary>
-        public Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log = null)
+        public Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
         {
             _log = log;
+
+            _apiUser = credentials[PARAM_API_USER];
+            _apiKey = credentials[PARAM_API_KEY];
+            _ip = credentials[PARAM_IP];
+
+            _http = new HttpClient();
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {

--- a/src/Certify.Providers/DNS/OVH/DnsProviderOvh.cs
+++ b/src/Certify.Providers/DNS/OVH/DnsProviderOvh.cs
@@ -3,17 +3,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Certify.Models.Config;
+using Certify.Models.Plugins;
 using Certify.Models.Providers;
 
 namespace Certify.Providers.DNS.OVH
 {
+    public class DnsProviderOvhProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
+
     /// <summary>
     /// OVH DNS API Provider contributed by contributed by https://github.com/laugel
     /// </summary>
     public class DnsProviderOvh : DnsProviderBase, IDnsProvider
     {
         private ILog _log;
-        private readonly Dictionary<string, string> credentials;
+        private Dictionary<string, string> credentials;
 
         private int? _customPropagationDelay = null;
         public int PropagationDelaySeconds => (_customPropagationDelay != null ? (int)_customPropagationDelay : Definition.PropagationDelaySeconds);
@@ -139,14 +142,15 @@ namespace Certify.Providers.DNS.OVH
             return new OvhClient(OvhApplicationEndpoint ?? DefaultOvhEndpoint, OvhApplicationKey, OvhApplicationSecret, OvhConsumerKey);
         }
 
-        public DnsProviderOvh(Dictionary<string, string> credentials)
+        public DnsProviderOvh()
         {
-            this.credentials = credentials;
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
         {
             _log = log;
+
+            this.credentials = credentials;
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {

--- a/src/Certify.Providers/DNS/SimpleDNSPlus/DnsProviderSimpleDNSPlus.cs
+++ b/src/Certify.Providers/DNS/SimpleDNSPlus/DnsProviderSimpleDNSPlus.cs
@@ -5,14 +5,14 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Certify.Models.Config;
+using Certify.Models.Plugins;
 using Certify.Models.Providers;
 using Newtonsoft.Json;
 
 namespace Certify.Providers.DNS.SimpleDNSPlus
 {
-    /// <summary>
-    /// SimpleDNSPlus DNS API Provider contributed by https://github.com/alphaz18
-    /// </summary>
+    public class DnsProviderSimpleDNSPlusProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
+
     internal class Zone
     {
         public string Domain { get; set; }
@@ -33,13 +33,16 @@ namespace Certify.Providers.DNS.SimpleDNSPlus
         public DnsRecord[] Result { get; set; }
     }
 
+    /// <summary>
+    /// SimpleDNSPlus DNS API Provider contributed by https://github.com/alphaz18
+    /// </summary>
     public class DnsProviderSimpleDNSPlus : DnsProviderBase, IDnsProvider
     {
         private ILog _log;
         private HttpClient _client = new HttpClient();
-        private readonly string _authKey;
-        private readonly string _authSecret;
-        private readonly string _authServer;
+        private string _authKey;
+        private string _authSecret;
+        private string _authServer;
         private string _baseUri;
         private string _listZonesUri;
         private string _createRecordUri;
@@ -88,12 +91,6 @@ namespace Certify.Providers.DNS.SimpleDNSPlus
 
         public DnsProviderSimpleDNSPlus(Dictionary<string, string> credentials)
         {
-            _authKey = credentials["authkey"];
-            _authSecret = credentials["authsecret"];
-            _authServer = credentials["authserver"];
-            _baseUri = "https://" + _authServer + "/v2/";
-            _listZonesUri = _baseUri + "zones";
-            _createRecordUri = _baseUri + "zones/{0}/records";
         }
 
         public async Task<ActionResult> Test()
@@ -265,9 +262,16 @@ namespace Certify.Providers.DNS.SimpleDNSPlus
             return zones;
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
         {
             _log = log;
+
+            _authKey = credentials["authkey"];
+            _authSecret = credentials["authsecret"];
+            _authServer = credentials["authserver"];
+            _baseUri = "https://" + _authServer + "/v2/";
+            _listZonesUri = _baseUri + "zones";
+            _createRecordUri = _baseUri + "zones/{0}/records";
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {

--- a/src/Certify.Shared/Management/PluginManager.cs
+++ b/src/Certify.Shared/Management/PluginManager.cs
@@ -71,8 +71,9 @@ namespace Certify.Management
             }
         }
 
-        private T LoadPlugin<T>(string dllFileName, Type interfaceType)
+        private T LoadPlugin<T>(string dllFileName)
         {
+            Type interfaceType = typeof(T);
             try
             {
                 var pluginPath = Path.Combine(GetPluginFolderPath(), dllFileName);
@@ -128,32 +129,34 @@ namespace Certify.Management
 
             if (includeSet.Contains("Licensing"))
             {
-                LicensingManager = LoadPlugin<ILicensingManager>("Plugin.Licensing.dll", typeof(ILicensingManager)) as ILicensingManager;
+                LicensingManager = LoadPlugin<ILicensingManager>("Plugin.Licensing.dll");
 
             }
 
             if (includeSet.Contains("DashboardClient"))
             {
-                DashboardClient = LoadPlugin<IDashboardClient>("Plugin.DashboardClient.dll", typeof(IDashboardClient)) as IDashboardClient;
+                DashboardClient = LoadPlugin<IDashboardClient>("Plugin.DashboardClient.dll");
             }
 
             if (includeSet.Contains("DeploymentTasks"))
             {
-                // TODO: wildcard filename match
-                var deploymentTaskPlugin = LoadPlugin<IDeploymentTaskProviderPlugin>("Plugin.DeploymentTasks.Core.dll", typeof(IDeploymentTaskProviderPlugin)) as IDeploymentTaskProviderPlugin;
-                DeploymentTaskProviders = new List<IDeploymentTaskProviderPlugin>
-                {
-                    deploymentTaskPlugin
-                };
-
-                var azure = LoadPlugin<IDeploymentTaskProviderPlugin>("Plugin.DeploymentTasks.Azure.dll", typeof(IDeploymentTaskProviderPlugin)) as IDeploymentTaskProviderPlugin;
-                DeploymentTaskProviders.Add(azure);
-
+                var deploymentTaskProviders = new List<IDeploymentTaskProviderPlugin>();
+                DeploymentTaskProviders = deploymentTaskProviders;
+                var core = LoadPlugin<IDeploymentTaskProviderPlugin>("Plugin.DeploymentTasks.Core.dll");
+                var azure = LoadPlugin<IDeploymentTaskProviderPlugin>("Plugin.DeploymentTasks.Azure.dll");
+                deploymentTaskProviders.Add(core);
+                deploymentTaskProviders.Add(azure);
+                var otherAssemblies = new DirectoryInfo(GetPluginFolderPath()).GetFiles("Plugin.DeploymentTasks.*.dll")
+                    .Where(f => 
+                        f.Name.ToUpperInvariant() != "PLUGIN.DEPLOYMENTTASKS.CORE.DLL" && 
+                        f.Name.ToUpperInvariant() != "PLUGIN.DEPLOYMENTTASKS.AZURE.DLL");
+                var others = otherAssemblies.Select(assem => LoadPlugin<IDeploymentTaskProviderPlugin>(assem.Name)).ToList();
+                deploymentTaskProviders.AddRange(others);
             }
 
             if (includeSet.Contains("CertificateManagers"))
             {
-                var certManagerProviders = LoadPlugin<ICertificateManagerProviderPlugin>("Plugin.CertificateManagers.dll", typeof(ICertificateManagerProviderPlugin)) as ICertificateManagerProviderPlugin;
+                var certManagerProviders = LoadPlugin<ICertificateManagerProviderPlugin>("Plugin.CertificateManagers.dll");
                 CertificateManagerProviders = new List<ICertificateManagerProviderPlugin>
                 {
                     certManagerProviders

--- a/src/Certify.Shared/Management/PluginManager.cs
+++ b/src/Certify.Shared/Management/PluginManager.cs
@@ -19,6 +19,12 @@ namespace Certify.Management
         public IDashboardClient DashboardClient { get; set; }
         public List<IDeploymentTaskProviderPlugin> DeploymentTaskProviders { get; set; }
         public List<ICertificateManagerProviderPlugin> CertificateManagerProviders { get; set; }
+        public List<IDnsProviderProviderPlugin> DnsProviderProviders { get; set; }
+        public bool DnsMSDNSFailedToLoad { get; private set; }
+
+        // ISSUE: Difficult to plumb PluginManager all the way through to ChallengeProviders, as that's about 7-8 layers deep on the call stack from where this is accessible.
+        // Since there's no injection container, making a cubbyhole for it here.
+        public static PluginManager _instance { get; private set; }
 
         private Models.Providers.ILog _log = null;
 
@@ -31,6 +37,10 @@ namespace Certify.Management
                         .CreateLogger()
                 );
 
+            if (_instance == null)
+            {
+                _instance = this;
+            }
         }
 
         public static string GetAppDataFolder(string subFolder = null)
@@ -161,6 +171,55 @@ namespace Certify.Management
                 {
                     certManagerProviders
                 };
+            }
+
+            if (includeSet.Contains("ChallengeProviders"))
+            {
+                var dnsProviderProviders = new List<IDnsProviderProviderPlugin>();
+                DnsProviderProviders = dnsProviderProviders;
+
+                // ISSUE: hidden dependency from Shared Core to Core, breaks layering
+                var builtInProvider = (IDnsProviderProviderPlugin)Activator.CreateInstance(Type.GetType("Certify.Core.Management.Challenges.ChallengeProviders+BuiltinDnsProviderProvider, Certify.Core"));
+                dnsProviderProviders.Add(builtInProvider);
+                var poshProvider = (IDnsProviderProviderPlugin)Activator.CreateInstance(Type.GetType("Certify.Core.Management.Challenges.DNS.DnsProviderPoshACME+PoshACMEDnsProviderProvider, Certify.Core"));
+                dnsProviderProviders.Add(poshProvider);
+
+                var inBoxProviders = new string[]
+                {
+                    "Certify.DNS.AcmeDns.dll",
+                    "Certify.DNS.Aliyun.dll",
+                    "Certify.DNS.AWSRoute53.dll",
+                    "Certify.DNS.Azure.dll",
+                    "Certify.DNS.Cloudflare.dll",
+                    "Certify.DNS.DnsMadeEasy.dll",
+                    "Certify.DNS.GoDaddy.dll",
+                    // MSDNS intentionally skipped due to special handling characteristics
+                    "Certify.DNS.NameCheap.dll",
+                    "Certify.DNS.OVH.dll",
+                    "Certify.DNS.SimpleDNSPlus.dll",
+                    "Certify.DNS.TransIP.dll"
+                };
+                foreach (var name in inBoxProviders)
+                {
+                    var plugin = LoadPlugin<IDnsProviderProviderPlugin>(name);
+                    dnsProviderProviders.Add(plugin);
+                }
+                
+                try
+                {
+                    var msdnsProvider = LoadPlugin<IDnsProviderProviderPlugin>("Certify.DNS.MicrosoftDns.dll");
+                    dnsProviderProviders.Add(msdnsProvider);
+                }
+                catch(Exception)
+                {
+                    // Microsoft.Management.Infrastructure is not available or Windows Management Framework for Powershell is not installed.
+                    // Remember that this happened so it can be reported later if needed.
+                    DnsMSDNSFailedToLoad = true;
+                }
+
+                var otherAssemblies = new DirectoryInfo(GetPluginFolderPath()).GetFiles("Plugin.DNS.*.dll");
+                var others = otherAssemblies.Select(assem => LoadPlugin<IDnsProviderProviderPlugin>(assem.Name)).ToList();
+                dnsProviderProviders.AddRange(others);
             }
 
             s.Stop();


### PR DESCRIPTION
I wanted to add a DNS provider to my local copy of Certify. Since it's rather niche, I didn't think it would make it upstream, so I investigated adding it as a plugin.

I noticed that Certify already had a plugin system for several components, such as deployment tasks, and that the DNS provider system came very close to that, but didn't quite fit. I also noticed that there were some comments about loading deployment task plugins by wildcard instead of by specific name as a future plan.

This pull request allows loading both deployment task plugins and DNS provider plugins by wildcard. It also alters the DNS provider infrastructure to work with the plugin system, which necessitated some small changes to each DNS provider; namely, credentials are now passed in `InitProvider` instead of the constructor so that providers can be constructed by definition ID alone.

There are some unresolved challenges, mainly in build process (how to ship the DNS provider DLLs now that they're plugins instead of hard references?) and architecture (how to get at the `PluginManager` from `ChallengeProviders` without breaking everything?).