### PR TITLE
Parameter in command line cli

### DIFF
--- a/src/Certify.CLI/CertifyCLI.AddRemove.cs
+++ b/src/Certify.CLI/CertifyCLI.AddRemove.cs
@@ -32,6 +32,12 @@ namespace Certify.CLI
                 performRequestNow = true;
             }
 
+            var preserveConfig = false;
+            if (args.Contains("--preserve-config"))
+            {
+                preserveConfig = true;
+            }
+
             if (domains != null && domains.Any())
             {
                 ManagedCertificate managedCert = null;
@@ -97,7 +103,7 @@ namespace Certify.CLI
                     }
                     else
                     {
-                        managedCert = templateCert.CopyAsTemplate();
+                        managedCert = templateCert.CopyAsTemplate(preserveConfig);
 
                         // if no managed cert name specifed, use first domain
                         if (string.IsNullOrEmpty(managedCert.Name))


### PR DESCRIPTION
When adding a new managed cert using the command line cli  `certify add --template c:\temp\someFile.json` . The `"DomainOptions"` and the `"RequestConfig"` are being cleared by default. 
This way, I can't use the `--perform-request` parameter because I don't have all my domain URLs added correctly. This way, I have to use the UI to finish my configuration, killing my automation.

In the method `CopyAsTemplate()` there is an parameter to set if we want to preserve the values of the Domain and Request config. But this parameter is never used. I've just added a new optional parameter in the cli to use the `CopyAsTemplate(preserveValues)` when call `certify add --template c:\temp\someFile.json --preserve-config`


