### PR TITLE
Fix to Simple.ps1 PS script used in TestLoadManagedCertificates

### DIFF
--- a/src/Certify.Tests/Certify.Core.Tests.Integration/Assets/Powershell/Simple.ps1
+++ b/src/Certify.Tests/Certify.Core.Tests.Integration/Assets/Powershell/Simple.ps1
@@ -2,7 +2,15 @@
 # Logs results to the given path (modify as required)
 
 param($result)  
-$logpath = "C:\Temp\Certify\TestOutput\TestPSOutput.txt"
+$logfile = "TestPSOutput.txt"
+$logdir = "C:\Temp\Certify\TestOutput\"
+$logpath = $logdir+$logfile
+
+if (!(Test-Path $logpath)) {
+  Write-Warning "$logpath does not exist, creating directories/file"
+  New-Item -ItemType "directory" -Path $logdir
+  New-Item -ItemType "file" -Path $logdir -Name $logfile
+}
 
 $date = Get-Date
 


### PR DESCRIPTION
Fixes when the log directory or file does not already exist on system
