### PR TITLE
Fix to Debug Port of Public.API always being overwritten by servers.json

### DIFF
--- a/src/Certify.Server/Certify.Server.Api.Public/Startup.cs
+++ b/src/Certify.Server/Certify.Server.Api.Public/Startup.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -141,7 +141,9 @@ namespace Certify.Server.API
 
             var connections = ServerConnectionManager.GetServerConnections(null, defaultConnectionConfig);
             var serverConnection = connections.FirstOrDefault(c => c.IsDefault == true);
-
+#if DEBUG
+            serverConnection = defaultConnectionConfig;
+#endif
             var internalServiceClient = new Client.CertifyServiceClient(configManager, serverConnection);
 
             internalServiceClient.ConnectStatusStreamAsync();


### PR DESCRIPTION
WebUI would not launch in Debug mode because the default servers.json file always overwrites the debug port values (9695) with release port (9696) when ServerConnectionManager.GetServerConnections() is called on line 142.

There may be a better logic flow that can be implemented here, but we must decide if the env variables for port and host should override the values in servers.json when CERTIFY_SERVER_HOST and CERTIFY_SERVER_PORT are not empty or null.
