### PR TITLE
Fix to make sure that errors from not loading the datastore are throw up

### DIFF
--- a/src/Certify.Core/Management/CertifyManager/CertifyManager.DataStores.cs
+++ b/src/Certify.Core/Management/CertifyManager/CertifyManager.DataStores.cs
@@ -113,7 +113,7 @@ namespace Certify.Management
 
             if (dataStore == null)
             {
-                _serviceLog.Error($"Could not match data store connection information to the specified store id: {dataStore.Id}");
+                _serviceLog.Error($"Could not match data store connection information to the specified store id: {dataStoreId}");
                 return false;
             }
 


### PR DESCRIPTION
Current logic references dataStore.Id when dataStore is null, leading to unhandled exception error.
