### PR TITLE
AccessControl Unit Test Updates and Enhancements

### DIFF
--- a/src/Certify.Core/Management/Access/AccessControl.cs
+++ b/src/Certify.Core/Management/Access/AccessControl.cs
@@ -64,9 +64,11 @@ namespace Certify.Core.Management.Access
                 return false;
             }
 
-            var updated = _store.Update<SecurityPrinciple>(nameof(SecurityPrinciple), principle);
-
-            if (updated.IsCompleted != true)
+            try
+            {
+                var updated = _store.Update<SecurityPrinciple>(nameof(SecurityPrinciple), principle);
+            }
+            catch
             {
                 _log?.Warning($"User {contextUserId} attempted to use UpdateSecurityPrinciple [{principle?.Id}], but was not successful");
                 return false;
@@ -138,7 +140,8 @@ namespace Certify.Core.Management.Access
 
             if (spAssignedPolicies.Any(a => a.ResourceActions.Contains(actionId)))
             {
-                // if any of the service principles assigned roles are restricted by the type of resource type, check for identifier matches (e.g. role assignment restricted on domains )
+                // if any of the service principles assigned roles are restricted by the type of resource type,
+                // check for identifier matches (e.g. role assignment restricted on domains )
                 if (spSpecificAssignedRoles.Any(a => a.IncludedResources.Any(r => r.ResourceType == resourceType)))
                 {
                     var allIncludedResources = spSpecificAssignedRoles.SelectMany(a => a.IncludedResources).Distinct();

--- a/src/Certify.Core/Management/Access/AccessControl.cs
+++ b/src/Certify.Core/Management/Access/AccessControl.cs
@@ -64,7 +64,13 @@ namespace Certify.Core.Management.Access
                 return false;
             }
 
-            await _store.Update<SecurityPrinciple>(nameof(SecurityPrinciple), principle);
+            var updated = _store.Update<SecurityPrinciple>(nameof(SecurityPrinciple), principle);
+
+            if (updated.IsCompleted != true)
+            {
+                _log?.Warning($"User {contextUserId} attempted to use UpdateSecurityPrinciple [{principle?.Id}], but was not successful");
+                return false;
+            }
 
             _log?.Information($"User {contextUserId} updated security principle [{principle?.Id}] {principle?.Username}");
             return true;
@@ -92,8 +98,13 @@ namespace Certify.Core.Management.Access
 
             var existing = await GetSecurityPrinciple(contextUserId, id);
 
-            await _store.Delete<SecurityPrinciple>(nameof(SecurityPrinciple), id);
+            var deleted = await _store.Delete<SecurityPrinciple>(nameof(SecurityPrinciple), id);
 
+            if (deleted != true)
+            {
+                _log?.Warning($"User {contextUserId} attempted to delete security principle [{id}] {existing?.Username}, but was not successful");
+                return false;
+            }
             // TODO: remove assigned roles
 
             _log?.Information($"User {contextUserId} deleted security principle [{id}] {existing?.Username}");
@@ -127,7 +138,7 @@ namespace Certify.Core.Management.Access
 
             if (spAssignedPolicies.Any(a => a.ResourceActions.Contains(actionId)))
             {
-                // if and of the service principles assigned roles are restricted by the type of resource type, check for identifier matches (e.g. role assignment restricted on domains )
+                // if any of the service principles assigned roles are restricted by the type of resource type, check for identifier matches (e.g. role assignment restricted on domains )
                 if (spSpecificAssignedRoles.Any(a => a.IncludedResources.Any(r => r.ResourceType == resourceType)))
                 {
                     var allIncludedResources = spSpecificAssignedRoles.SelectMany(a => a.IncludedResources).Distinct();

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/AccessControlTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/AccessControlTests.cs
@@ -54,7 +54,13 @@ namespace Certify.Core.Tests.Unit
             var o = item as AccessStoreItem;
             _store.TryGetValue(o.Id, out var value);
             var c = Task.FromResult((T)Convert.ChangeType(value, typeof(T))).Result as AccessStoreItem;
-            return Task.FromResult(_store.TryUpdate(o.Id, o, c));
+            var r = Task.FromResult(_store.TryUpdate(o.Id, o, c));
+            if(r.Result == false)
+            {
+                throw new Exception("Could not store item type");
+            }
+
+            return r;
         }
     }
 
@@ -182,6 +188,23 @@ namespace Certify.Core.Tests.Unit
         }
 
         [TestMethod]
+        public async Task TestAccessControlGetSecurityPrinciplesNoRoles()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger();
+            var loggy = new Loggy(log);
+            var access = new AccessControl(loggy, new MemoryObjectStore());
+            var contextUserId = "[test]";
+
+            // Add test security principles
+            var securityPrincipleAdded = await access.AddSecurityPrinciple(contextUserId, TestSecurityPrinciples.TestAdmin());
+
+            // Get stored security principles
+            Assert.IsFalse(securityPrincipleAdded, $"Expected AddSecurityPrinciple() to be unsuccessful without roles defined for {contextUserId}");
+        }
+
+        [TestMethod]
         public async Task TestAccessControlAddGetSecurityPrinciple()
         {
             var log = new LoggerConfiguration()
@@ -247,6 +270,52 @@ namespace Certify.Core.Tests.Unit
         }
 
         [TestMethod]
+        public async Task TestAccessControlGetAssignedRolesNoRoles()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger();
+            var loggy = new Loggy(log);
+            var access = new AccessControl(loggy, new MemoryObjectStore());
+            var contextUserId = "[test]";
+
+            // Add test security principles
+            var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
+            adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
+
+            // Validate AssignedRole list returned by AccessControl.GetAssignedRoles()
+            var adminAssignedRoles = await access.GetAssignedRoles(contextUserId, adminSecurityPrinciples[0].Id);
+            Assert.IsNotNull(adminAssignedRoles, "Expected list returned by AccessControl.GetAssignedRoles() to not be null");
+            Assert.AreEqual(0, adminAssignedRoles.Count, "Expected list returned by AccessControl.GetAssignedRoles() to have no AssignedRole objects");
+        }
+
+        [TestMethod]
+        public async Task TestAccessControlAddResourcePolicyNoRoles()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger();
+            var loggy = new Loggy(log);
+            var access = new AccessControl(loggy, new MemoryObjectStore());
+            var contextUserId = "[test]";
+
+            // Add test security principles
+            var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
+            adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
+
+            // Setup security principle actions
+            var actions = Policies.GetStandardResourceActions().FindAll(a => a.ResourceType == ResourceTypes.System);
+            actions.ForEach(async a => await access.AddAction(a));
+
+            // Setup policy with actions and add policy to store
+            var policy = Policies.GetStandardPolicies().Find(p => p.Id == "access_admin");
+            var addedResourcePolicy = await access.AddResourcePolicy(contextUserId, policy);
+
+            // Validate that AddResourcePolicy() failed when no roles are defined
+            Assert.IsFalse(addedResourcePolicy, $"Unable to add a resource policy using {contextUserId} when roles are undefined");
+        }
+
+        [TestMethod]
         public async Task TestAccessControlUpdateSecurityPrinciple()
         {
             var log = new LoggerConfiguration()
@@ -290,6 +359,73 @@ namespace Certify.Core.Tests.Unit
             storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, newSecurityPrinciple.Id);
             Assert.AreNotEqual(storedSecurityPrinciple.Email, adminSecurityPrinciples[0].Email, $"Expected SecurityPrinciple returned by GetSecurityPrinciple() to not match previous Email '{adminSecurityPrinciples[0].Email}' of SecurityPrinciple passed into AddSecurityPrinciple()");
             Assert.AreEqual(storedSecurityPrinciple.Email, newSecurityPrinciple.Email, $"Expected SecurityPrinciple returned by GetSecurityPrinciple() to match updated Email '{newSecurityPrinciple.Email}' of SecurityPrinciple passed into AddSecurityPrinciple()");
+        }
+
+        [TestMethod]
+        public async Task TestAccessControlUpdateSecurityPrincipleNoRoles()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger();
+            var loggy = new Loggy(log);
+            var access = new AccessControl(loggy, new MemoryObjectStore());
+            var contextUserId = "[test]";
+
+            // Add test security principles
+            var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
+            adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
+
+            // Validate email of SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() before update
+            var storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[0].Id);
+            Assert.AreEqual(storedSecurityPrinciple.Email, adminSecurityPrinciples[0].Email, $"Expected SecurityPrinciple returned by GetSecurityPrinciple() to match Email '{adminSecurityPrinciples[0].Email}' of SecurityPrinciple passed into AddSecurityPrinciple()");
+
+            // Update security principle in AccessControl with a new principle object of the same Id, but different email, with roles undefined
+            var newSecurityPrinciple = TestSecurityPrinciples.Admin();
+            newSecurityPrinciple.Email = "new_test_email@test.com";
+            var securityPrincipleUpdated = await access.UpdateSecurityPrinciple(contextUserId, newSecurityPrinciple);
+            Assert.IsFalse(securityPrincipleUpdated, $"Expected security principle update for {newSecurityPrinciple.Id} to be unsuccessful without roles defined");
+        }
+
+        [TestMethod]
+        public async Task TestAccessControlUpdateSecurityPrincipleBadUpdate()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger();
+            var loggy = new Loggy(log);
+            var access = new AccessControl(loggy, new MemoryObjectStore());
+            var contextUserId = "[test]";
+
+            // Add test security principles
+            var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
+            adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
+
+            // Setup security principle actions
+            var actions = Policies.GetStandardResourceActions().FindAll(a => a.ResourceType == ResourceTypes.System);
+            actions.ForEach(async a => await access.AddAction(a));
+
+            // Setup policy with actions and add policy to store
+            var policy = Policies.GetStandardPolicies().Find(p => p.Id == "access_admin");
+            _ = await access.AddResourcePolicy(contextUserId, policy, bypassIntegrityCheck: true);
+
+            // Setup and add roles and policy assignments to store
+            var role = (await access.GetSystemRoles()).Find(r => r.Id == StandardRoles.Administrator.Id);
+            await access.AddRole(role);
+
+            // Assign security principles to roles and add roles and policy assignments to store
+            var assignedRoles = new List<AssignedRole> { TestAssignedRoles.Admin, TestAssignedRoles.TestAdmin };
+            assignedRoles.ForEach(async r => await access.AddAssignedRole(r));
+
+            // Validate email of SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() before update
+            var storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[0].Id);
+            Assert.AreEqual(storedSecurityPrinciple.Email, adminSecurityPrinciples[0].Email, $"Expected SecurityPrinciple returned by GetSecurityPrinciple() to match Email '{adminSecurityPrinciples[0].Email}' of SecurityPrinciple passed into AddSecurityPrinciple()");
+
+            // Update security principle in AccessControl with a new principle object with a bad Id name and different email
+            var newSecurityPrinciple = TestSecurityPrinciples.Admin();
+            newSecurityPrinciple.Email = "new_test_email@test.com";
+            newSecurityPrinciple.Id = "missing_username";
+            var securityPrincipleUpdated = await access.UpdateSecurityPrinciple(contextUserId, newSecurityPrinciple);
+            Assert.IsFalse(securityPrincipleUpdated, $"Expected security principle update for {newSecurityPrinciple.Id} to be unsuccessful with bad update data (Id does not already exist in store)");
         }
 
         [TestMethod]
@@ -341,6 +477,74 @@ namespace Certify.Core.Tests.Unit
         }
 
         [TestMethod]
+        public async Task TestAccessControlUpdateSecurityPrinciplePasswordNoRoles()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger();
+            var loggy = new Loggy(log);
+            var access = new AccessControl(loggy, new MemoryObjectStore());
+            var contextUserId = "[test]";
+
+            // Add test security principles
+            var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
+            var firstPassword = adminSecurityPrinciples[0].Password;
+            adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
+
+            // Update security principle in AccessControl with a new password
+            var newPassword = "GFEDCBA";
+            var securityPrincipleUpdated = await access.UpdateSecurityPrinciplePassword(contextUserId, adminSecurityPrinciples[0].Id, firstPassword, newPassword);
+            Assert.IsFalse(securityPrincipleUpdated, $"Expected security principle password update for {adminSecurityPrinciples[0].Id} to fail without roles");
+
+            // Validate password of SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() after failed update
+            var storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[0].Id);
+            var firstPasswordHashed = access.HashPassword(firstPassword, storedSecurityPrinciple.Password.Split('.')[1]);
+            Assert.AreEqual(storedSecurityPrinciple.Password, firstPasswordHashed, $"Expected SecurityPrinciple returned by GetSecurityPrinciple() to match Password '{firstPasswordHashed}' of SecurityPrinciple passed into AddSecurityPrinciple()");
+        }
+
+        [TestMethod]
+        public async Task TestAccessControlUpdateSecurityPrinciplePasswordBadPassword()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger();
+            var loggy = new Loggy(log);
+            var access = new AccessControl(loggy, new MemoryObjectStore());
+            var contextUserId = "[test]";
+
+            // Add test security principles
+            var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
+            var firstPassword = adminSecurityPrinciples[0].Password;
+            adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
+
+            // Setup security principle actions
+            var actions = Policies.GetStandardResourceActions().FindAll(a => a.ResourceType == ResourceTypes.System);
+            actions.ForEach(async a => await access.AddAction(a));
+
+            // Setup policy with actions and add policy to store
+            var policy = Policies.GetStandardPolicies().Find(p => p.Id == "access_admin");
+            _ = await access.AddResourcePolicy(contextUserId, policy, bypassIntegrityCheck: true);
+
+            // Setup and add roles and policy assignments to store
+            var role = (await access.GetSystemRoles()).Find(r => r.Id == StandardRoles.Administrator.Id);
+            await access.AddRole(role);
+
+            // Assign security principles to roles and add roles and policy assignments to store
+            var assignedRoles = new List<AssignedRole> { TestAssignedRoles.Admin, TestAssignedRoles.TestAdmin };
+            assignedRoles.ForEach(async r => await access.AddAssignedRole(r));
+
+            // Update security principle in AccessControl with a new password, but wrong original password
+            var newPassword = "GFEDCBA";
+            var securityPrincipleUpdated = await access.UpdateSecurityPrinciplePassword(contextUserId, adminSecurityPrinciples[0].Id, firstPassword.ToLower(), newPassword);
+            Assert.IsFalse(securityPrincipleUpdated, $"Expected security principle password update for {adminSecurityPrinciples[0].Id} to fail with wrong password");
+
+            // Validate password of SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() after failed update
+            var storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[0].Id);
+            var firstPasswordHashed = access.HashPassword(firstPassword, storedSecurityPrinciple.Password.Split('.')[1]);
+            Assert.AreEqual(storedSecurityPrinciple.Password, firstPasswordHashed, $"Expected SecurityPrinciple returned by GetSecurityPrinciple() to match Password '{firstPasswordHashed}' of SecurityPrinciple passed into AddSecurityPrinciple()");
+        }
+
+        [TestMethod]
         public async Task TestAccessControlDeleteSecurityPrinciple()
         {
             var log = new LoggerConfiguration()
@@ -377,10 +581,127 @@ namespace Certify.Core.Tests.Unit
 
             // Delete first security principle in adminSecurityPrinciples list from AccessControl store
             var securityPrincipleDeleted = await access.DeleteSecurityPrinciple(contextUserId, adminSecurityPrinciples[0].Id);
+            Assert.IsTrue(securityPrincipleDeleted, $"Expected security principle deletion for {adminSecurityPrinciples[0].Id} to succeed");
 
             // Validate SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() after delete is null
             storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[0].Id);
             Assert.IsNull(storedSecurityPrinciple, $"Expected SecurityPrinciple for '{adminSecurityPrinciples[0].Id}' to be null from GetSecurityPrinciple()");
+        }
+
+        [TestMethod]
+        public async Task TestAccessControlDeleteSecurityPrincipleNoRoles()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger();
+            var loggy = new Loggy(log);
+            var access = new AccessControl(loggy, new MemoryObjectStore());
+            var contextUserId = "[test]";
+
+            // Add test security principles
+            var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
+            adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
+
+            // Validate SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() before delete is not null
+            var storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[0].Id);
+            Assert.IsNotNull(storedSecurityPrinciple, "Expected object returned by AccessControl.GetSecurityPrinciple() to not be null");
+            Assert.AreEqual(storedSecurityPrinciple.Id, adminSecurityPrinciples[0].Id, $"Expected SecurityPrinciple returned by GetSecurityPrinciple() to match Id '{adminSecurityPrinciples[0].Id}' of SecurityPrinciple passed into AddSecurityPrinciple()");
+
+            // Try to delete first security principle in adminSecurityPrinciples list from AccessControl store
+            var securityPrincipleDeleted = await access.DeleteSecurityPrinciple(contextUserId, adminSecurityPrinciples[0].Id);
+            Assert.IsFalse(securityPrincipleDeleted, $"Expected security principle deletion for {adminSecurityPrinciples[0].Id} to fail without roles defined");
+
+            // Validate SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() after delete is not null
+            storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[0].Id);
+            Assert.IsNotNull(storedSecurityPrinciple, $"Expected SecurityPrinciple for '{adminSecurityPrinciples[0].Id}' to not be null from GetSecurityPrinciple()");
+        }
+
+        [TestMethod]
+        public async Task TestAccessControlDeleteSecurityPrincipleSelfDeletion()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger();
+            var loggy = new Loggy(log);
+            var access = new AccessControl(loggy, new MemoryObjectStore());
+            var contextUserId = "[test]";
+
+            // Add test security principles
+            var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
+            adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
+
+            // Setup security principle actions
+            var actions = Policies.GetStandardResourceActions().FindAll(a => a.ResourceType == ResourceTypes.System);
+            actions.ForEach(async a => await access.AddAction(a));
+
+            // Setup policy with actions and add policy to store
+            var policy = Policies.GetStandardPolicies().Find(p => p.Id == "access_admin");
+            _ = await access.AddResourcePolicy(contextUserId, policy, bypassIntegrityCheck: true);
+
+            // Setup and add roles and policy assignments to store
+            var role = (await access.GetSystemRoles()).Find(r => r.Id == StandardRoles.Administrator.Id);
+            await access.AddRole(role);
+
+            // Assign security principles to roles and add roles and policy assignments to store
+            var assignedRoles = new List<AssignedRole> { TestAssignedRoles.Admin, TestAssignedRoles.TestAdmin };
+            assignedRoles.ForEach(async r => await access.AddAssignedRole(r));
+
+            // Validate SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() before delete is not null
+            var storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[1].Id);
+            Assert.IsNotNull(storedSecurityPrinciple, "Expected object returned by AccessControl.GetSecurityPrinciple() to not be null");
+            Assert.AreEqual(storedSecurityPrinciple.Id, adminSecurityPrinciples[1].Id, $"Expected SecurityPrinciple returned by GetSecurityPrinciple() to match Id '{adminSecurityPrinciples[1].Id}' of SecurityPrinciple passed into AddSecurityPrinciple()");
+
+            // Try to delete second security principle in adminSecurityPrinciples list from AccessControl store
+            var securityPrincipleDeleted = await access.DeleteSecurityPrinciple(contextUserId, contextUserId);
+            Assert.IsFalse(securityPrincipleDeleted, $"Expected security principle self deletion for {contextUserId} to fail");
+
+            // Validate SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() after delete is not null
+            storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[1].Id);
+            Assert.IsNotNull(storedSecurityPrinciple, $"Expected SecurityPrinciple for '{adminSecurityPrinciples[1].Id}' to not be null from GetSecurityPrinciple()");
+        }
+
+        [TestMethod]
+        public async Task TestAccessControlDeleteSecurityPrincipleBadId()
+        {
+            var log = new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger();
+            var loggy = new Loggy(log);
+            var access = new AccessControl(loggy, new MemoryObjectStore());
+            var contextUserId = "[test]";
+
+            // Add test security principles
+            var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
+            adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
+
+            // Setup security principle actions
+            var actions = Policies.GetStandardResourceActions().FindAll(a => a.ResourceType == ResourceTypes.System);
+            actions.ForEach(async a => await access.AddAction(a));
+
+            // Setup policy with actions and add policy to store
+            var policy = Policies.GetStandardPolicies().Find(p => p.Id == "access_admin");
+            _ = await access.AddResourcePolicy(contextUserId, policy, bypassIntegrityCheck: true);
+
+            // Setup and add roles and policy assignments to store
+            var role = (await access.GetSystemRoles()).Find(r => r.Id == StandardRoles.Administrator.Id);
+            await access.AddRole(role);
+
+            // Assign security principles to roles and add roles and policy assignments to store
+            var assignedRoles = new List<AssignedRole> { TestAssignedRoles.Admin, TestAssignedRoles.TestAdmin };
+            assignedRoles.ForEach(async r => await access.AddAssignedRole(r));
+
+            // Validate SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() before delete is not null
+            var storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[1].Id);
+            Assert.IsNotNull(storedSecurityPrinciple, "Expected object returned by AccessControl.GetSecurityPrinciple() to not be null");
+            Assert.AreEqual(storedSecurityPrinciple.Id, adminSecurityPrinciples[1].Id, $"Expected SecurityPrinciple returned by GetSecurityPrinciple() to match Id '{adminSecurityPrinciples[1].Id}' of SecurityPrinciple passed into AddSecurityPrinciple()");
+
+            // Try to delete second security principle in adminSecurityPrinciples list from AccessControl store
+            var securityPrincipleDeleted = await access.DeleteSecurityPrinciple(contextUserId, contextUserId.ToUpper());
+            Assert.IsFalse(securityPrincipleDeleted, $"Expected security principle deletion for {contextUserId.ToUpper()} to fail");
+
+            // Validate SecurityPrinciple object returned by AccessControl.GetSecurityPrinciple() after delete is not null
+            storedSecurityPrinciple = await access.GetSecurityPrinciple(contextUserId, adminSecurityPrinciples[1].Id);
+            Assert.IsNotNull(storedSecurityPrinciple, $"Expected SecurityPrinciple for '{adminSecurityPrinciples[1].Id}' to not be null from GetSecurityPrinciple()");
         }
 
         [TestMethod]

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/AccessControlTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/AccessControlTests.cs
@@ -161,16 +161,22 @@ namespace Certify.Core.Tests.Unit
     [TestClass]
     public class AccessControlTests
     {
+        private Loggy loggy;
+        private AccessControl access;
+        private const string contextUserId = "[test]";
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this.loggy = new Loggy(new LoggerConfiguration()
+                .WriteTo.Debug()
+                .CreateLogger());
+            this.access = new AccessControl(loggy, new MemoryObjectStore());
+        }
+
         [TestMethod]
         public async Task TestAccessControlAddGetSecurityPrinciples()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -190,13 +196,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlGetSecurityPrinciplesNoRoles()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var securityPrincipleAdded = await access.AddSecurityPrinciple(contextUserId, TestSecurityPrinciples.TestAdmin());
 
@@ -207,13 +206,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlAddGetSecurityPrinciple()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -232,13 +224,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlAddGetAssignedRoles()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -272,13 +257,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlGetAssignedRolesNoRoles()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -292,13 +270,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlAddResourcePolicyNoRoles()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -318,13 +289,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlUpdateSecurityPrinciple()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -364,13 +328,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlUpdateSecurityPrincipleNoRoles()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -389,13 +346,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlUpdateSecurityPrincipleBadUpdate()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -431,13 +381,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlUpdateSecurityPrinciplePassword()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             var firstPassword = adminSecurityPrinciples[0].Password;
@@ -479,13 +422,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlUpdateSecurityPrinciplePasswordNoRoles()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             var firstPassword = adminSecurityPrinciples[0].Password;
@@ -505,13 +441,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlUpdateSecurityPrinciplePasswordBadPassword()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             var firstPassword = adminSecurityPrinciples[0].Password;
@@ -547,13 +476,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlDeleteSecurityPrinciple()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -591,13 +513,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlDeleteSecurityPrincipleNoRoles()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -619,13 +534,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlDeleteSecurityPrincipleSelfDeletion()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -663,13 +571,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlDeleteSecurityPrincipleBadId()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -707,13 +608,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlIsPrincipleInRole()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test security principles
             var adminSecurityPrinciples = new List<SecurityPrinciple> { TestSecurityPrinciples.Admin(), TestSecurityPrinciples.TestAdmin() };
             adminSecurityPrinciples.ForEach(async p => await access.AddSecurityPrinciple(contextUserId, p, bypassIntegrityCheck: true));
@@ -750,13 +644,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlDomainAuth()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test devops user security principle
             _ = await access.AddSecurityPrinciple(contextUserId, TestSecurityPrinciples.DevopsUser(), bypassIntegrityCheck: true);
 
@@ -786,13 +673,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlWildcardDomainAuth()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test devops user security principle
             _ = await access.AddSecurityPrinciple(contextUserId, TestSecurityPrinciples.DevopsUser(), bypassIntegrityCheck: true);
 
@@ -826,13 +706,6 @@ namespace Certify.Core.Tests.Unit
         [TestMethod]
         public async Task TestAccessControlRandomUserAuth()
         {
-            var log = new LoggerConfiguration()
-                .WriteTo.Debug()
-                .CreateLogger();
-            var loggy = new Loggy(log);
-            var access = new AccessControl(loggy, new MemoryObjectStore());
-            var contextUserId = "[test]";
-
             // Add test devops user security principle
             _ = await access.AddSecurityPrinciple(contextUserId, TestSecurityPrinciples.DevopsUser(), bypassIntegrityCheck: true);
 

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/AccessControlTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/AccessControlTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -52,7 +52,9 @@ namespace Certify.Core.Tests.Unit
         public Task Update<T>(string itemType, T item)
         {
             var o = item as AccessStoreItem;
-            return Task.FromResult(_store.TryUpdate(o.Id, o, o));
+            _store.TryGetValue(o.Id, out var value);
+            var c = Task.FromResult((T)Convert.ChangeType(value, typeof(T))).Result as AccessStoreItem;
+            return Task.FromResult(_store.TryUpdate(o.Id, o, c));
         }
     }
 


### PR DESCRIPTION
Split up existing unit test for AccessControl into multiple tests, and added multiple new happy path and negative tests to enhance coverage. This PR Increases AccessControl code coverage from 56.9% to 98.8%, one if-logic branch of IsAuthorised() is still uncovered on line 174 of AccessControl.

UpdateSecurityPrinciple() and DeleteSecurityPrinciple() methods in AccessControl updated to detect when mutation attempt on data store is unsuccessful.

Also updated Update method for MemoryObjectStore in AccessControlTests to properly use ConcurrentDictionary.TryUpdate(), as current implementation did not actually update data store due to lack of correct comparison object (see https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.tryupdate?view=net-7.0#parameters)

https://github.com/webprofusion/certify-general/issues/7