### PR TITLE
Fall back to the CIM cmdlet when WMIC is deprecated.

### DIFF
--- a/src/Certify.Shared.Extensions/Scripts/Common/RDPListenerService.ps1
+++ b/src/Certify.Shared.Extensions/Scripts/Common/RDPListenerService.ps1
@@ -7,4 +7,14 @@
 param($result)
 
 # Apply certificate
-wmic /namespace:\\root\cimv2\TerminalServices PATH Win32_TSGeneralSetting Set SSLCertificateSHA1Hash="$($result.ManagedItem.CertificateThumbprintHash)"
+if (Get-Command wmic -errorAction SilentlyContinue)
+{
+    # Beginning with Windows Server 2025, WMIC is available as a feature on demand.
+    wmic /namespace:\\root\cimv2\TerminalServices PATH Win32_TSGeneralSetting Set SSLCertificateSHA1Hash="$($result.ManagedItem.CertificateThumbprintHash)"
+}
+else
+{
+    # For new development, use the CIM cmdlets instead.
+    $instance = Get-CimInstance -ClassName Win32_TSGeneralSetting -Namespace root/cimv2/TerminalServices
+    Set-CimInstance -InputObject $instance -Property @{SSLCertificateSHA1Hash=$result.ManagedItem.CertificateThumbprintHash}
+}


### PR DESCRIPTION
[Beginning with Windows Server 2025, WMIC is available as a feature on demand.
](https://learn.microsoft.com/en-us/windows-server/get-started/removed-deprecated-features-windows-server-2025#:~:text=Beginning%20with%20Windows%20Server%202025%2C%20WMIC%20is%20available%20as%20a%20feature%20on%20demand)

![image](https://github.com/user-attachments/assets/8c8123aa-c55d-439b-9099-e744169c66e1)