### PR TITLE
Adds proxy support for DNS providers

### DIFF
--- a/src/Certify.Core/Management/Challenges/ChallengeProviders.cs
+++ b/src/Certify.Core/Management/Challenges/ChallengeProviders.cs
@@ -8,6 +8,7 @@ using Certify.Models;
 using Certify.Models.Config;
 using Certify.Models.Plugins;
 using Certify.Models.Providers;
+using Certify.Shared.Net;
 
 namespace Certify.Core.Management.Challenges
 {
@@ -214,7 +215,7 @@ namespace Certify.Core.Management.Challenges
             }
             else
             {
-                await dnsAPIProvider.InitProvider(credentials, parameters, log);
+                await dnsAPIProvider.InitProvider(credentials, parameters, new HttpClientProvider(new ProxyProvider()), log);
             }
 
             return dnsAPIProvider;

--- a/src/Certify.Core/Management/Challenges/DNS/DnsChallengeHelper.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsChallengeHelper.cs
@@ -47,7 +47,7 @@ namespace Certify.Core.Management.Challenges
         {
         }
 
-        public Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null) => Task.FromResult(true);
+        public Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null) => Task.FromResult(true);
         public Task<ActionResult> Test() => Task.FromResult(new ActionResult { IsSuccess = true, Message = $"{Definition.Title} provider currently does not support tests." });
         public Task<ActionResult> CreateRecord(DnsRecord request) => Task.FromResult(new ActionResult { IsSuccess = true, Message = $"{Definition.Title} provider currently does not support tests." });
         public Task<ActionResult> DeleteRecord(DnsRecord request) => Task.FromResult(new ActionResult { IsSuccess = true, Message = $"{Definition.Title} provider currently does not support tests." });

--- a/src/Certify.Core/Management/Challenges/DNS/DnsProviderLibcloud.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsProviderLibcloud.cs
@@ -82,22 +82,6 @@ namespace Certify.Core.Management.Challenges
                 // test - wait for DNS changes
                 await Task.Delay(5000);
 
-                // do our own txt record query before proceeding with challenge completion
-                /*
-                int attempts = 3;
-                bool recordCheckedOK = false;
-                var networkUtil = new NetworkUtils(false);
-
-                while (attempts > 0 && !recordCheckedOK)
-                {
-                    recordCheckedOK = networkUtil.CheckDNSRecordTXT(domain, txtRecordName, txtRecordValue);
-                    attempts--;
-                    if (!recordCheckedOK)
-                    {
-                        await Task.Delay(1000); // hold on a sec
-                    }
-                }
-                */
                 return helperResult;
             }
             else
@@ -112,7 +96,7 @@ namespace Certify.Core.Management.Challenges
 
         public Task<List<DnsZone>> GetZones() => throw new NotImplementedException();
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log)
         {
             _log = log;
             return await Task.FromResult(true);

--- a/src/Certify.Core/Management/Challenges/DNS/DnsProviderManual.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsProviderManual.cs
@@ -59,7 +59,7 @@ namespace Certify.Core.Management.Challenges.DNS
 
         Task<List<DnsZone>> IDnsProvider.GetZones() => Task.FromResult(new List<DnsZone>());
 
-        Task<bool> IDnsProvider.InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log)
+        Task<bool> IDnsProvider.InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
 

--- a/src/Certify.Core/Management/Challenges/DNS/DnsProviderScripting.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsProviderScripting.cs
@@ -84,7 +84,7 @@ namespace Certify.Core.Management.Challenges.DNS
 
         Task<List<DnsZone>> IDnsProvider.GetZones() => Task.FromResult(new List<DnsZone>());
 
-        Task<bool> IDnsProvider.InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log)
+        Task<bool> IDnsProvider.InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
 

--- a/src/Certify.Models/Config/Preferences.cs
+++ b/src/Certify.Models/Config/Preferences.cs
@@ -20,6 +20,26 @@ namespace Certify.Models
         FullCleanup = 3
     }
 
+    public enum ProxyMode
+    {
+        /// <summary>
+        /// No proxy configured
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Use system default proxy settings
+        /// </summary>
+        System = 1,
+        /// <summary>
+        /// Use environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
+        /// </summary>
+        Environment = 2,
+        /// <summary>
+        /// Use custom proxy configuration
+        /// </summary>
+        Custom = 3
+    }
+
     public static class RenewalIntervalModes
     {
         /// <summary>
@@ -142,6 +162,41 @@ namespace Certify.Models
         /// Preferences for external certificate managers (enable/disable, config/log paths)
         /// </summary>
         public List<CertificateManagerPreference> CertificateManagers { get; set; } = new List<CertificateManagerPreference>();
+
+        /// <summary>
+        /// If true, proxy configuration is enabled for outbound HTTP requests
+        /// </summary>
+        public bool ProxyEnabled { get; set; }
+
+        /// <summary>
+        /// Proxy mode: None, System, Environment, or Custom
+        /// </summary>
+        public ProxyMode ProxyMode { get; set; } = ProxyMode.None;
+
+        /// <summary>
+        /// Custom proxy URI (e.g., http://proxy.example.com:8080)
+        /// </summary>
+        public string? ProxyUri { get; set; }
+
+        /// <summary>
+        /// If true, bypass proxy for local addresses
+        /// </summary>
+        public bool ProxyBypassOnLocal { get; set; } = true;
+
+        /// <summary>
+        /// Comma-separated list of addresses to bypass proxy (e.g., localhost,127.0.0.1,*.local)
+        /// </summary>
+        public string? ProxyBypassList { get; set; }
+
+        /// <summary>
+        /// If true, use default network credentials for proxy authentication
+        /// </summary>
+        public bool ProxyUseDefaultCredentials { get; set; }
+
+        /// <summary>
+        /// Storage key for proxy credentials (references a StoredCredential)
+        /// </summary>
+        public string? ProxyCredentialKey { get; set; }
     }
 
     public static class FeatureFlags

--- a/src/Certify.Models/Providers/IDnsProvider.cs
+++ b/src/Certify.Models/Providers/IDnsProvider.cs
@@ -43,7 +43,7 @@ namespace Certify.Models.Providers
 
     public interface IDnsProvider
     {
-        Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null);
+        Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider,  ILog log = null);
 
         /// <summary>
         /// Perform a test of credentials, usually by listings DNS zones

--- a/src/Certify.Models/Providers/IHttpClientProvider.cs
+++ b/src/Certify.Models/Providers/IHttpClientProvider.cs
@@ -1,0 +1,31 @@
+﻿using System.Net;
+using System.Net.Http;
+
+namespace Certify.Models.Providers
+{
+    /// <summary>
+    /// Factory for creating HttpClient and HttpMessageHandler instances with proxy support
+    /// </summary>
+    public interface IHttpClientProvider
+    {
+        /// <summary>
+        /// Create an HttpClient configured with proxy settings for external/internet requests
+        /// </summary>
+        HttpClient CreateClient();
+
+        /// <summary>
+        /// Create an HttpClient without proxy for service-to-service communication
+        /// </summary>
+        HttpClient CreateInternalClient();
+
+        /// <summary>
+        /// Create an HttpMessageHandler configured with proxy settings
+        /// </summary>
+        HttpMessageHandler CreateHandler();
+
+        /// <summary>
+        /// Create an HttpMessageHandler without proxy
+        /// </summary>
+        HttpMessageHandler CreateInternalHandler();
+    }
+}

--- a/src/Certify.Models/Providers/IHttpClientProvider.cs
+++ b/src/Certify.Models/Providers/IHttpClientProvider.cs
@@ -14,6 +14,12 @@ namespace Certify.Models.Providers
         HttpClient CreateClient();
 
         /// <summary>
+        /// Create an HttpClient configured with proxy settings for external/internet requests
+        /// </summary>
+        /// <param name="userAgent">Optional user agent string to set on the client</param>
+        HttpClient CreateClient(string? userAgent = null, bool allowInvalidTls = false);
+
+        /// <summary>
         /// Create an HttpClient without proxy for service-to-service communication
         /// </summary>
         HttpClient CreateInternalClient();
@@ -21,7 +27,7 @@ namespace Certify.Models.Providers
         /// <summary>
         /// Create an HttpMessageHandler configured with proxy settings
         /// </summary>
-        HttpMessageHandler CreateHandler();
+        HttpMessageHandler CreateHandler(bool allowInvalidTls = false);
 
         /// <summary>
         /// Create an HttpMessageHandler without proxy

--- a/src/Certify.Providers/ACME/Anvil/AnvilACMEProvider.cs
+++ b/src/Certify.Providers/ACME/Anvil/AnvilACMEProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -148,6 +148,9 @@ namespace Certify.Providers.ACME.Anvil
             {
                 httpHandler.ServerCertificateCustomValidationCallback = (message, certificate, chain, sslPolicyErrors) => true;
             }
+
+            // Apply proxy configuration from environment if configured
+            Certify.Shared.Net.ProxyHelper.ApplyProxyIfConfigured(httpHandler);
 
             _loggingHandler = new LoggingHandler(httpHandler, _log, maxRequestsPerSecond: 2);
             var customHttpClient = new System.Net.Http.HttpClient(_loggingHandler);

--- a/src/Certify.Providers/DNS/AWSRoute53/DnsProviderAWSRoute53.cs
+++ b/src/Certify.Providers/DNS/AWSRoute53/DnsProviderAWSRoute53.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Amazon.Route53;
 using Amazon.Route53.Model;
@@ -332,11 +333,31 @@ namespace Certify.Providers.DNS.AWSRoute53
             return results;
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
 
-            _route53Client = new AmazonRoute53Client(credentials["accesskey"], credentials["secretaccesskey"], Amazon.RegionEndpoint.USEast1);
+            var route53Config = new AmazonRoute53Config
+            {
+                RegionEndpoint = Amazon.RegionEndpoint.USEast1
+            };
+
+            // Configure proxy if needed
+
+            var handler = clientProvider.CreateHandler();
+            if (handler is HttpClientHandler httpClientHandler && httpClientHandler.Proxy != null)
+            {
+                route53Config.ProxyHost = httpClientHandler.Proxy.GetProxy(new Uri("https://route53.amazonaws.com"))?.Host;
+                route53Config.ProxyPort = httpClientHandler.Proxy.GetProxy(new Uri("https://route53.amazonaws.com"))?.Port ?? 0;
+
+                // If proxy credentials are required
+                if (httpClientHandler.Proxy.Credentials != null)
+                {
+                    route53Config.ProxyCredentials = httpClientHandler.Proxy.Credentials;
+                }
+            }
+
+            _route53Client = new AmazonRoute53Client(credentials["accesskey"], credentials["secretaccesskey"], route53Config);
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {

--- a/src/Certify.Providers/DNS/AcmeDns/AcmeDns/DnsProviderAcmeDns.cs
+++ b/src/Certify.Providers/DNS/AcmeDns/AcmeDns/DnsProviderAcmeDns.cs
@@ -92,9 +92,6 @@ namespace Certify.Providers.DNS.AcmeDns
         {
             _settingsPath = EnvironmentUtil.EnsuredAppDataPath();
 
-            _client = new HttpClient();
-            _client.DefaultRequestHeaders.Add("User-Agent", "Certify/DnsProviderAcmeDns");
-
             _serializerSettings = new JsonSerializerSettings
             {
                 Formatting = Formatting.None,
@@ -339,11 +336,13 @@ namespace Certify.Providers.DNS.AcmeDns
             return await Task.FromResult(results);
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _credentials = credentials;
             _log = log;
             _parameters = parameters;
+
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {

--- a/src/Certify.Providers/DNS/Aliyun/DnsProviderAliyun.cs
+++ b/src/Certify.Providers/DNS/Aliyun/DnsProviderAliyun.cs
@@ -19,9 +19,10 @@ namespace Certify.Providers.DNS.Aliyun
     /// Alibaba Cloud DNS API Provider contributed by https://github.com/TkYu
     /// </summary>
     /// 
-    public class DnsProviderAliyun : DnsProviderBase, IDnsProvider
+    public class DnsProviderAliyun : DnsProviderBase, IDnsProvider, IDisposable
     {
         private ILog _log;
+        private HttpClient _client;
 
         private string _accessKeyId;
         private string _accessKeySecret;
@@ -217,7 +218,6 @@ namespace Certify.Providers.DNS.Aliyun
 
         public override async Task<List<DnsZone>> GetZones()
         {
-            //TODO does aliyun really have Zones?
             var zones = new List<DnsZone>();
             var finishedPaginating = false;
             var page = 1;
@@ -255,11 +255,13 @@ namespace Certify.Providers.DNS.Aliyun
             return zones;
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
             _accessKeyId = credentials["accesskeyid"];
             _accessKeySecret = credentials["accesskeysecret"];
+
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {
@@ -309,12 +311,10 @@ namespace Certify.Providers.DNS.Aliyun
 
             var request = new AliDnsRequest(HttpMethod.Get, _accessKeyId, _accessKeySecret, parameters);
             var url = request.GetUrl();
-            using (var httpClient = new HttpClient())
-            {
-                var response = await httpClient.GetAsync(url);
-                var content = await response.Content.ReadAsStringAsync();
-                return JsonConvert.DeserializeObject<DomainRecord>(content);
-            }
+
+            var response = await _client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<DomainRecord>(content);
         }
 
         private async Task<DomainRecord> DeleteDomainRecord(string recordId)
@@ -326,12 +326,10 @@ namespace Certify.Providers.DNS.Aliyun
             };
             var request = new AliDnsRequest(HttpMethod.Get, _accessKeyId, _accessKeySecret, parameters);
             var url = request.GetUrl();
-            using (var httpClient = new HttpClient())
-            {
-                var response = await httpClient.GetAsync(url);
-                var content = await response.Content.ReadAsStringAsync();
-                return JsonConvert.DeserializeObject<DomainRecord>(content);
-            }
+
+            var response = await _client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<DomainRecord>(content);
         }
 
         private async Task<DescribeDomainRecords> GetDomainRecords(string domain, int pageNumber = 1, int pageSize = 20)
@@ -345,12 +343,10 @@ namespace Certify.Providers.DNS.Aliyun
             };
             var request = new AliDnsRequest(HttpMethod.Get, _accessKeyId, _accessKeySecret, parameters);
             var url = request.GetUrl();
-            using (var httpClient = new HttpClient())
-            {
-                var response = await httpClient.GetAsync(url);
-                var content = await response.Content.ReadAsStringAsync();
-                return JsonConvert.DeserializeObject<DescribeDomainRecords>(content);
-            }
+
+            var response = await _client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<DescribeDomainRecords>(content);
         }
 
         private async Task<DescribeDomainsResponse> GetDomains(int pageNumber = 1, int pageSize = 20)
@@ -363,12 +359,15 @@ namespace Certify.Providers.DNS.Aliyun
             };
             var request = new AliDnsRequest(HttpMethod.Get, _accessKeyId, _accessKeySecret, parameters);
             var url = request.GetUrl();
-            using (var httpClient = new HttpClient())
-            {
-                var response = await httpClient.GetAsync(url);
-                var content = await response.Content.ReadAsStringAsync();
-                return JsonConvert.DeserializeObject<DescribeDomainsResponse>(content);
-            }
+
+            var response = await _client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<DescribeDomainsResponse>(content);
+        }
+
+        public void Dispose()
+        {
+            _client?.Dispose();
         }
 
         #endregion AliMethods

--- a/src/Certify.Providers/DNS/Azure/DnsProviderAzure.cs
+++ b/src/Certify.Providers/DNS/Azure/DnsProviderAzure.cs
@@ -1,8 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Azure;
+using Azure.Core;
+using Azure.Core.Pipeline;
 using Azure.Identity;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Dns;
@@ -51,14 +54,14 @@ namespace Certify.Providers.DNS.Azure
             HelpUrl = "https://docs.certifytheweb.com/docs/dns/providers/azuredns",
             PropagationDelaySeconds = 60,
             ProviderParameters = new List<ProviderParameter>{
-                        new ProviderParameter{ Key="service",Name="Azure Service", IsRequired=true, IsPassword=false, IsCredential=true, Value="global", OptionsList="global=Azure Cloud; china=Azure China; germany=Azure Germany (deprecated); usgov=Azure US Government" },
-                        new ProviderParameter{ Key="tenantid", Name="Directory (tenant) Id", IsRequired=false },
-                        new ProviderParameter{ Key="clientid", Name="Application (client) Id", IsRequired=false },
-                        new ProviderParameter{ Key="secret",Name="Client Secret", IsRequired=true , IsPassword=true},
-                        new ProviderParameter{ Key="subscriptionid",Name="DNS Subscription Id", IsRequired=true , IsPassword=false},
-                        new ProviderParameter{ Key="resourcegroupname",Name="Resource Group Name", IsRequired=true , IsPassword=false},
-                        new ProviderParameter{ Key="zoneid",Name="DNS Zone Name", IsRequired=true, IsPassword=false, IsCredential=false }
-                    },
+                new ProviderParameter{ Key="service",Name="Azure Service", IsRequired=true, IsPassword=false, IsCredential=true, Value="global", OptionsList="global=Azure Cloud; china=Azure China; germany=Azure Germany (deprecated); usgov=Azure US Government" },
+                new ProviderParameter{ Key="tenantid", Name="Directory (tenant) Id", IsRequired=false },
+                new ProviderParameter{ Key="clientid", Name="Application (client) Id", IsRequired=false },
+                new ProviderParameter{ Key="secret",Name="Client Secret", IsRequired=true , IsPassword=true},
+                new ProviderParameter{ Key="subscriptionid",Name="DNS Subscription Id", IsRequired=true , IsPassword=false},
+                new ProviderParameter{ Key="resourcegroupname",Name="Resource Group Name", IsRequired=true , IsPassword=false},
+                new ProviderParameter{ Key="zoneid",Name="DNS Zone Name", IsRequired=true, IsPassword=false, IsCredential=false }
+            },
             ChallengeType = Models.SupportedChallengeTypes.CHALLENGE_TYPE_DNS,
             Config = "Provider=Certify.Providers.DNS.Azure",
             HandlerType = ChallengeHandlerType.INTERNAL
@@ -110,7 +113,7 @@ namespace Certify.Providers.DNS.Azure
             }
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
 
@@ -121,8 +124,24 @@ namespace Certify.Providers.DNS.Azure
 
             _credentials.TryGetValue("service", out var azureServiceEnvironment);
 
-            var azureCred = new ClientSecretCredential(credentials["tenantid"], credentials["clientid"], credentials["secret"], new ClientSecretCredentialOptions { AuthorityHost = MapServiceToAuthorityHost(azureServiceEnvironment) });
-            _azureClient = new ArmClient(azureCred, credentials["subscriptionid"], new ArmClientOptions { Environment = MapAzureServiceToAzureEnvironment(azureServiceEnvironment) });
+            var azureCred = new ClientSecretCredential(
+                credentials["tenantid"],
+                credentials["clientid"],
+                credentials["secret"],
+                new ClientSecretCredentialOptions { AuthorityHost = MapServiceToAuthorityHost(azureServiceEnvironment) }
+            );
+
+            // Create HttpClient transport using IHttpClientProvider for proxy support
+            var httpClient = clientProvider.CreateClient($"Certify/{Definition.Id}");
+            var transport = new HttpClientTransport(httpClient);
+
+            var armClientOptions = new ArmClientOptions
+            {
+                Environment = MapAzureServiceToAzureEnvironment(azureServiceEnvironment),
+                Transport = transport
+            };
+
+            _azureClient = new ArmClient(azureCred, credentials["subscriptionid"], armClientOptions);
             _subscription = await _azureClient.GetDefaultSubscriptionAsync();
 
             if (parameters?.ContainsKey("propagationdelay") == true)

--- a/src/Certify.Providers/DNS/CertifyDns/DnsProviderCertifyDns.cs
+++ b/src/Certify.Providers/DNS/CertifyDns/DnsProviderCertifyDns.cs
@@ -40,7 +40,7 @@ namespace Certify.Providers.DNS.CertifyDns
 
     public class DnsProviderCertifyDnsProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
 
-    public class DnsProviderCertifyDns : IDnsProvider
+    public class DnsProviderCertifyDns : IDnsProvider, IDisposable
     {
         public static ChallengeProviderDefinition Definition
         {
@@ -67,15 +67,10 @@ namespace Certify.Providers.DNS.CertifyDns
             }
         }
 
-        public DnsProviderCertifyDns(IHttpClientProvider clientProvider = null) : base()
+        public DnsProviderCertifyDns()
         {
-            EnableExtensions = true;
-
+            _enableExtensions = true;
             _settingsPath = EnvironmentUtil.EnsuredAppDataPath();
-
-            _client = clientProvider?.CreateClient() ?? new HttpClient();
-            _client.DefaultRequestHeaders.Add("User-Agent", "Certify/DnsProviderCertifyDns");
-
             _serializerSettings = new JsonSerializerSettings
             {
                 Formatting = Formatting.None,
@@ -91,9 +86,9 @@ namespace Certify.Providers.DNS.CertifyDns
         private int? _customPropagationDelay = null;
 
         /// <summary>
-        /// if true, enable extensions to the base standard
+        /// if true, enable extensions to the base standard e.g. subject field
         /// </summary>
-        public bool EnableExtensions = false;
+        private bool _enableExtensions = false;
 
         public int PropagationDelaySeconds => (_customPropagationDelay != null ? (int)_customPropagationDelay : Definition.PropagationDelaySeconds);
 
@@ -226,7 +221,7 @@ namespace Certify.Providers.DNS.CertifyDns
                 }
             }
 
-            if (EnableExtensions)
+            if (_enableExtensions)
             {
                 registration.subject = domainId;
             }
@@ -348,11 +343,13 @@ namespace Certify.Providers.DNS.CertifyDns
             return await Task.FromResult(results);
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _credentials = credentials;
             _log = log;
             _parameters = parameters;
+
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {
@@ -378,6 +375,10 @@ namespace Certify.Providers.DNS.CertifyDns
         {
             var bytes = System.Text.UTF8Encoding.UTF8.GetBytes(val);
             return ToUrlSafeBase64String(bytes);
+        }
+
+        public void Dispose() {
+            _client?.Dispose();
         }
     }
 }

--- a/src/Certify.Providers/DNS/CertifyDns/DnsProviderCertifyDns.cs
+++ b/src/Certify.Providers/DNS/CertifyDns/DnsProviderCertifyDns.cs
@@ -67,13 +67,13 @@ namespace Certify.Providers.DNS.CertifyDns
             }
         }
 
-        public DnsProviderCertifyDns() : base()
+        public DnsProviderCertifyDns(IHttpClientProvider clientProvider = null) : base()
         {
             EnableExtensions = true;
 
             _settingsPath = EnvironmentUtil.EnsuredAppDataPath();
 
-            _client = new HttpClient();
+            _client = clientProvider?.CreateClient() ?? new HttpClient();
             _client.DefaultRequestHeaders.Add("User-Agent", "Certify/DnsProviderCertifyDns");
 
             _serializerSettings = new JsonSerializerSettings

--- a/src/Certify.Providers/DNS/CertifyManaged/DnsProviderCertifyManaged.cs
+++ b/src/Certify.Providers/DNS/CertifyManaged/DnsProviderCertifyManaged.cs
@@ -45,23 +45,27 @@ namespace Certify.Providers.DNS.CertifyManaged
             }
         }
 
-        public DnsProviderCertifyManaged() : base()
+        public DnsProviderCertifyManaged(IHttpClientProvider clientProvider = null) : base()
         {
-
 #if DEBUG
-            // allow invalid TLS
-            var handler = new HttpClientHandler();
-            handler.ClientCertificateOptions = ClientCertificateOption.Manual;
-            handler.ServerCertificateCustomValidationCallback =
-                (httpRequestMessage, cert, cetChain, policyErrors) =>
-                {
-                    return true;
-                };
-            _client = new HttpClient(handler);
-
+            if (clientProvider != null)
+            {
+                _client = clientProvider.CreateClient();
+            }
+            else
+            {
+                // allow invalid TLS
+                var handler = new HttpClientHandler();
+                handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+                handler.ServerCertificateCustomValidationCallback =
+                    (httpRequestMessage, cert, cetChain, policyErrors) =>
+                    {
+                        return true;
+                    };
+                _client = new HttpClient(handler);
+            }
 #else
-            _client = new HttpClient();
-
+            _client = clientProvider?.CreateClient() ?? new HttpClient();
 #endif
             _client.DefaultRequestHeaders.Add("User-Agent", "Certify/DnsProviderCertifyManaged");
 

--- a/src/Certify.Providers/DNS/CertifyManaged/DnsProviderCertifyManaged.cs
+++ b/src/Certify.Providers/DNS/CertifyManaged/DnsProviderCertifyManaged.cs
@@ -19,7 +19,7 @@ namespace Certify.Providers.DNS.CertifyManaged
 {
     public class DnsProviderCertifyManagedProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
 
-    public class DnsProviderCertifyManaged : IDnsProvider
+    public class DnsProviderCertifyManaged : IDnsProvider, IDisposable
     {
         public static ChallengeProviderDefinition Definition
         {
@@ -45,36 +45,8 @@ namespace Certify.Providers.DNS.CertifyManaged
             }
         }
 
-        public DnsProviderCertifyManaged(IHttpClientProvider clientProvider = null) : base()
+        public DnsProviderCertifyManaged() : base()
         {
-#if DEBUG
-            if (clientProvider != null)
-            {
-                _client = clientProvider.CreateClient();
-            }
-            else
-            {
-                // allow invalid TLS
-                var handler = new HttpClientHandler();
-                handler.ClientCertificateOptions = ClientCertificateOption.Manual;
-                handler.ServerCertificateCustomValidationCallback =
-                    (httpRequestMessage, cert, cetChain, policyErrors) =>
-                    {
-                        return true;
-                    };
-                _client = new HttpClient(handler);
-            }
-#else
-            _client = clientProvider?.CreateClient() ?? new HttpClient();
-#endif
-            _client.DefaultRequestHeaders.Add("User-Agent", "Certify/DnsProviderCertifyManaged");
-
-            _serializerSettings = new JsonSerializerSettings
-            {
-                Formatting = Formatting.None,
-                MissingMemberHandling = MissingMemberHandling.Ignore,
-                NullValueHandling = NullValueHandling.Ignore
-            };
         }
 
         private Dictionary<string, string> _credentials;
@@ -103,7 +75,6 @@ namespace Certify.Providers.DNS.CertifyManaged
 
         private JsonSerializerSettings _serializerSettings;
 
-        private string _settingsPath { get; set; }
         private Uri _apiBaseUri { get; set; }
 
         public async Task<ActionResult> Test()
@@ -239,17 +210,24 @@ namespace Certify.Providers.DNS.CertifyManaged
             }
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _credentials = credentials;
             _log = log;
             _parameters = parameters;
 
-            if (_credentials == null || _credentials.Count == 0)
+#if DEBUG
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}", allowInvalidTls: true);
+#else
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
+#endif
+
+            _serializerSettings = new JsonSerializerSettings
             {
-                _log.Error("Certify Managed Challenge DNS Provider could not be created: credentials missing or not set for managed challenge API.");
-                return false;
-            }
+                Formatting = Formatting.None,
+                MissingMemberHandling = MissingMemberHandling.Ignore,
+                NullValueHandling = NullValueHandling.Ignore
+            };
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {
@@ -257,6 +235,12 @@ namespace Certify.Providers.DNS.CertifyManaged
                 {
                     _customPropagationDelay = customPropDelay;
                 }
+            }
+
+            if (_credentials == null || _credentials.Count == 0)
+            {
+                _log?.Error("Certify Managed Challenge DNS Provider could not be created: credentials missing or not set for managed challenge API.");
+                return false;
             }
 
             if (_parameters.TryGetValue("api", out var apiBase) && !string.IsNullOrWhiteSpace(apiBase))
@@ -277,9 +261,7 @@ namespace Certify.Providers.DNS.CertifyManaged
 
                 if (!string.IsNullOrWhiteSpace(mgmtHubAPI))
                 {
-                    // if we have a management hub API URL, use that
                     _apiBaseUri = new System.Uri(mgmtHubAPI);
-
                     if (!_apiBaseUri.ToString().EndsWith("/"))
                     {
                         _apiBaseUri = new Uri($"{_apiBaseUri}/");
@@ -289,7 +271,7 @@ namespace Certify.Providers.DNS.CertifyManaged
                 }
                 else
                 {
-                    _log.Error("Certify Managed Challenge DNS Provider could not be created: managed challenge API URL not set.");
+                    _log?.Error("Certify Managed Challenge DNS Provider could not be created: managed challenge API URL not set.");
                     return false;
                 }
             }
@@ -300,6 +282,10 @@ namespace Certify.Providers.DNS.CertifyManaged
         public Task<List<DnsZone>> GetZones()
         {
             return Task.FromResult(new List<DnsZone>());
+        }
+
+        public void Dispose() { 
+            _client?.Dispose();
         }
     }
 }

--- a/src/Certify.Providers/DNS/Cloudflare/DnsProviderCloudflare.cs
+++ b/src/Certify.Providers/DNS/Cloudflare/DnsProviderCloudflare.cs
@@ -124,8 +124,9 @@ namespace Certify.Providers.DNS.Cloudflare
             HandlerType = ChallengeHandlerType.INTERNAL
         };
 
-        public DnsProviderCloudflare()
+        public DnsProviderCloudflare(IHttpClientProvider clientProvider = null)
         {
+            _client = clientProvider?.CreateClient() ?? new HttpClient();
         }
 
         public async Task<ActionResult> Test()
@@ -425,8 +426,11 @@ namespace Certify.Providers.DNS.Cloudflare
         public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
         {
             _log = log;
-
-            _client = new HttpClient();
+            // Use client created in constructor if it was already set (from DI)
+            if (_client == null)
+            {
+                _client = new HttpClient();
+            }
 
             var credentialError = $"{ProviderTitle} requires either an API Token or an Email Address + AuthKey";
 

--- a/src/Certify.Providers/DNS/Cloudflare/DnsProviderCloudflare.cs
+++ b/src/Certify.Providers/DNS/Cloudflare/DnsProviderCloudflare.cs
@@ -72,7 +72,7 @@ namespace Certify.Providers.DNS.Cloudflare
     /// <remarks> 
     /// See <see cref="https://api.cloudflare.com/#getting-started-endpoints" /> for more details.
     /// </remarks>
-    public class DnsProviderCloudflare : IDnsProvider
+    public class DnsProviderCloudflare : IDnsProvider, IDisposable
     {
         private ILog _log;
 
@@ -124,9 +124,8 @@ namespace Certify.Providers.DNS.Cloudflare
             HandlerType = ChallengeHandlerType.INTERNAL
         };
 
-        public DnsProviderCloudflare(IHttpClientProvider clientProvider = null)
+        public DnsProviderCloudflare()
         {
-            _client = clientProvider?.CreateClient() ?? new HttpClient();
         }
 
         public async Task<ActionResult> Test()
@@ -423,14 +422,11 @@ namespace Certify.Providers.DNS.Cloudflare
             return zones;
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
-            // Use client created in constructor if it was already set (from DI)
-            if (_client == null)
-            {
-                _client = new HttpClient();
-            }
+
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
 
             var credentialError = $"{ProviderTitle} requires either an API Token or an Email Address + AuthKey";
 
@@ -457,6 +453,11 @@ namespace Certify.Providers.DNS.Cloudflare
             }
 
             return await Task.FromResult(true);
+        }
+
+        public void Dispose()
+        {
+            _client?.Dispose();
         }
     }
 }

--- a/src/Certify.Providers/DNS/DnsMadeEasy/DnsProviderDnsMadeEasy.cs
+++ b/src/Certify.Providers/DNS/DnsMadeEasy/DnsProviderDnsMadeEasy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -41,7 +41,7 @@ namespace Certify.Providers.DNS.DnsMadeEasy
 
         private static string _apiUrl = "https://api.dnsmadeeasy.com/V2.0/";
 
-        private static readonly HttpClient _httpClient;
+        private HttpClient _client;
         private string _apiKey;
         private string _apiSecret;
         private bool _useSandbox = false;
@@ -82,7 +82,6 @@ namespace Certify.Providers.DNS.DnsMadeEasy
 
         static DnsProviderDnsMadeEasy()
         {
-            _httpClient = new HttpClient();
         }
 
         private static string ComputeHMAC(string input, string key)
@@ -157,7 +156,7 @@ namespace Certify.Providers.DNS.DnsMadeEasy
 
             apiRequest.Content.Headers.ContentType.MediaType = "application/json";
 
-            var result = await _httpClient.SendAsync(apiRequest);
+            var result = await _client.SendAsync(apiRequest);
 
             if (!result.IsSuccessStatusCode)
             {
@@ -212,7 +211,7 @@ namespace Certify.Providers.DNS.DnsMadeEasy
                     //delete existing record
                     var url = $"{_apiUrl}dns/managed/{request.ZoneId}/records/{r.RecordId}";
                     var apiRequest = CreateRequest(HttpMethod.Delete, url, DateTimeOffset.Now);
-                    var result = await _httpClient.SendAsync(apiRequest);
+                    var result = await _client.SendAsync(apiRequest);
 
                     if (!result.IsSuccessStatusCode)
                     {
@@ -233,7 +232,7 @@ namespace Certify.Providers.DNS.DnsMadeEasy
             var url = $"{_apiUrl}dns/managed/{zoneId}/records/";
 
             var request = CreateRequest(HttpMethod.Get, url, DateTimeOffset.Now);
-            var response = await _httpClient.SendAsync(request);
+            var response = await _client.SendAsync(request);
 
             if (response.IsSuccessStatusCode)
             {
@@ -258,7 +257,7 @@ namespace Certify.Providers.DNS.DnsMadeEasy
             var url = $"{_apiUrl}dns/managed/";
 
             var request = CreateRequest(HttpMethod.Get, url, DateTimeOffset.Now);
-            var response = await _httpClient.SendAsync(request);
+            var response = await _client.SendAsync(request);
 
             if (response.IsSuccessStatusCode)
             {
@@ -278,11 +277,13 @@ namespace Certify.Providers.DNS.DnsMadeEasy
             }
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
             _apiKey = credentials["apikey"];
             _apiSecret = credentials["apisecret"];
+
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {
@@ -326,6 +327,7 @@ namespace Certify.Providers.DNS.DnsMadeEasy
 
         public void Dispose()
         {
+            _client?.Dispose();
         }
     }
 }

--- a/src/Certify.Providers/DNS/GoDaddy/DnsProviderGoDaddy.cs
+++ b/src/Certify.Providers/DNS/GoDaddy/DnsProviderGoDaddy.cs
@@ -36,7 +36,7 @@ namespace Certify.Providers.DNS.GoDaddy
     /// <summary>
     /// GoDaddy DNS API Provider contributed by https://github.com/alphaz18
     /// </summary>
-    public class DnsProviderGoDaddy : DnsProviderBase, IDnsProvider
+    public class DnsProviderGoDaddy : DnsProviderBase, IDnsProvider, IDisposable
     {
         private ILog _log;
         private HttpClient _client;
@@ -347,15 +347,17 @@ namespace Certify.Providers.DNS.GoDaddy
             }
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
 
             _authKey = credentials["authkey"];
             _authSecret = credentials["authsecret"];
 
-            _client = new HttpClient();
-            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
+
+            _client.DefaultRequestHeaders.Remove("Accept");
+            _client.DefaultRequestHeaders.Add("Accept", "application/json");
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {
@@ -366,6 +368,10 @@ namespace Certify.Providers.DNS.GoDaddy
             }
 
             return await Task.FromResult(true);
+        }
+
+        public void Dispose() {
+            _client?.Dispose();
         }
     }
 }

--- a/src/Certify.Providers/DNS/IONOS/DnsProviderIONOS.cs
+++ b/src/Certify.Providers/DNS/IONOS/DnsProviderIONOS.cs
@@ -17,7 +17,7 @@ namespace Certify.Providers.DNS.IONOS
     {
     }
 
-    public class DnsProviderIONOS : DnsProviderBase, IDnsProvider
+    public class DnsProviderIONOS : DnsProviderBase, IDnsProvider, IDisposable
     {
 
         private ILog _log;
@@ -41,13 +41,12 @@ namespace Certify.Providers.DNS.IONOS
             HelpUrl = "https://developer.hosting.ionos.com/docs/getstarted"
         };
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters,
-            ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
             _credentials = credentials;
 
-            _client = new HttpClient();
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
 
             return await Task.FromResult(true);
         }
@@ -225,6 +224,10 @@ namespace Certify.Providers.DNS.IONOS
             request.Headers.Add("X-API-Key", $"{_credentials["public"]}.{_credentials["secret"]}");
             request.Headers.Add("User-Agent", "Certify");
             return request;
+        }
+
+        public void Dispose() {
+            _client?.Dispose();
         }
 
         public int PropagationDelaySeconds => Definition.PropagationDelaySeconds;

--- a/src/Certify.Providers/DNS/MSDNS/DnsProviderMSDNS.cs
+++ b/src/Certify.Providers/DNS/MSDNS/DnsProviderMSDNS.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security;
@@ -127,7 +127,7 @@ namespace Certify.Providers.DNS.MSDNS
             return await Task.FromResult(zones);
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
 

--- a/src/Certify.Providers/DNS/NameCheap/DnsProviderNameCheap.cs
+++ b/src/Certify.Providers/DNS/NameCheap/DnsProviderNameCheap.cs
@@ -16,7 +16,7 @@ namespace Certify.Providers.DNS.NameCheap
 {
     public class DnsProviderNameCheapProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
 
-    public class DnsProviderNameCheap : IDnsProvider
+    public class DnsProviderNameCheap : IDnsProvider, IDisposable
     {
         public DnsProviderNameCheap()
         {
@@ -26,7 +26,7 @@ namespace Certify.Providers.DNS.NameCheap
         private string _apiKey;
         private string _ip;
 
-        private HttpClient _http;
+        private HttpClient _client;
 
         private ILog _log;
 
@@ -87,7 +87,7 @@ namespace Certify.Providers.DNS.NameCheap
         /// <summary>
         /// Initializes the provider.
         /// </summary>
-        public Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
 
@@ -95,7 +95,7 @@ namespace Certify.Providers.DNS.NameCheap
             _apiKey = credentials[PARAM_API_KEY];
             _ip = credentials[PARAM_IP];
 
-            _http = new HttpClient();
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {
@@ -353,7 +353,7 @@ namespace Certify.Providers.DNS.NameCheap
         /// </summary>
         private async Task<XElement> InvokeApiAsync(HttpRequestMessage request)
         {
-            var response = await _http.SendAsync(request);
+            var response = await _client.SendAsync(request);
             var content = await response.Content.ReadAsStringAsync();
 
             if (!response.IsSuccessStatusCode)
@@ -424,6 +424,10 @@ namespace Certify.Providers.DNS.NameCheap
                 SLD = matchingZone.Substring(0, dotPos),
                 TLD = matchingZone.Substring(dotPos + 1)
             };
+        }
+
+        public void Dispose() {
+            _client?.Dispose();
         }
 
         private class ParsedDomain

--- a/src/Certify.Providers/DNS/OVH/DnsProviderOvh.cs
+++ b/src/Certify.Providers/DNS/OVH/DnsProviderOvh.cs
@@ -168,7 +168,7 @@ namespace Certify.Providers.DNS.OVH
         {
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
 

--- a/src/Certify.Providers/DNS/SimpleDNSPlus/DnsProviderSimpleDNSPlus.cs
+++ b/src/Certify.Providers/DNS/SimpleDNSPlus/DnsProviderSimpleDNSPlus.cs
@@ -40,10 +40,10 @@ namespace Certify.Providers.DNS.SimpleDNSPlus
     /// <summary>
     /// SimpleDNSPlus DNS API Provider contributed by https://github.com/alphaz18
     /// </summary>
-    public class DnsProviderSimpleDNSPlus : DnsProviderBase, IDnsProvider
+    public class DnsProviderSimpleDNSPlus : DnsProviderBase, IDnsProvider, IDisposable
     {
         private ILog _log;
-        private HttpClient _client = new HttpClient();
+        private HttpClient _client = null;
         private string _authKey;
         private string _authSecret;
         private string _authServer;
@@ -266,9 +266,11 @@ namespace Certify.Providers.DNS.SimpleDNSPlus
             return zones;
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
+
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
 
             _authKey = credentials["authkey"];
             _authSecret = credentials["authsecret"];
@@ -295,6 +297,10 @@ namespace Certify.Providers.DNS.SimpleDNSPlus
             }
 
             return await Task.FromResult(true);
+        }
+
+        public void Dispose() {
+            _client?.Dispose();
         }
     }
 }

--- a/src/Certify.Providers/DNS/TransIP/Authentication/Authenticator.cs
+++ b/src/Certify.Providers/DNS/TransIP/Authentication/Authenticator.cs
@@ -17,16 +17,18 @@ namespace Certify.Providers.DNS.TransIP.Authentication
         private readonly Util _util;
         private readonly DigestCreator _digestCreator;
         private readonly DigestSigner _digestSigner;
-
+        private readonly HttpClient _client;
         private string _token = "";
         private DateTime _tokenValidUntil = DateTime.MinValue;
 
         public Authenticator(
             string login,
             string privateKey,
-            int loginDuration
+            int loginDuration,
+            HttpClient client
         )
         {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
             _login = login ?? throw new ArgumentNullException(nameof(login));
             _privateKey = privateKey ?? throw new ArgumentNullException(nameof(privateKey));
             _loginDuration = GetLoginDuration(loginDuration);
@@ -104,12 +106,14 @@ namespace Certify.Providers.DNS.TransIP.Authentication
             return _digestSigner.Sign(digest, _privateKey);
         }
 
-        private static async Task<HttpResponseMessage> Login(string loginRequest, string signature)
+        private async Task<HttpResponseMessage> Login(string loginRequest, string signature)
         {
             var content = new StringContent(loginRequest, Encoding.UTF8, "application/json");
-            var client = new HttpClient();
-            client.DefaultRequestHeaders.Add("Signature", signature);
-            return await client.PostAsync($"{DnsProviderTransIP.BASE_URI}auth", content);
+
+            _client.DefaultRequestHeaders.Remove("Signature");
+            _client.DefaultRequestHeaders.Add("Signature", signature);
+
+            return await _client.PostAsync($"{DnsProviderTransIP.BASE_URI}auth", content);
         }
 
         private ActionResult<string> ProcessResponse(HttpResponseMessage response)

--- a/src/Certify.Providers/DNS/TransIP/DnsClient.cs
+++ b/src/Certify.Providers/DNS/TransIP/DnsClient.cs
@@ -16,11 +16,12 @@ namespace Certify.Providers.DNS.TransIP
         internal DnsClient(
             string login,
             string privateKey,
-            int loginDuration)
+            int loginDuration,
+            HttpClient client = null)
         {
             _authenticator = new Authenticator(login, privateKey, loginDuration);
 
-            _client = new HttpClient();
+            _client = client ?? new HttpClient();
         }
 
         private async Task<ActionResult<HttpRequestMessage>> CreateRequest(HttpMethod method, string url)

--- a/src/Certify.Providers/DNS/TransIP/DnsClient.cs
+++ b/src/Certify.Providers/DNS/TransIP/DnsClient.cs
@@ -17,11 +17,11 @@ namespace Certify.Providers.DNS.TransIP
             string login,
             string privateKey,
             int loginDuration,
-            HttpClient client = null)
+            HttpClient client)
         {
-            _authenticator = new Authenticator(login, privateKey, loginDuration);
+            _authenticator = new Authenticator(login, privateKey, loginDuration, client);
 
-            _client = client ?? new HttpClient();
+            _client = client;
         }
 
         private async Task<ActionResult<HttpRequestMessage>> CreateRequest(HttpMethod method, string url)
@@ -33,7 +33,10 @@ namespace Certify.Providers.DNS.TransIP
             }
 
             var request = new HttpRequestMessage(method, url);
+            
+            request.Headers.Remove("Authorization");
             request.Headers.Add("Authorization", $"Bearer {login.Result}");
+            
             return new ActionResult<HttpRequestMessage> { IsSuccess = true, Result = request };
         }
 

--- a/src/Certify.Providers/DNS/TransIP/DnsProviderTransIP.cs
+++ b/src/Certify.Providers/DNS/TransIP/DnsProviderTransIP.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,7 +12,7 @@ namespace Certify.Providers.DNS.TransIP
 {
     public class DnsProviderTransIPProvider : PluginProviderBase<IDnsProvider, ChallengeProviderDefinition>, IDnsProviderProviderPlugin { }
 
-    public class DnsProviderTransIP : DnsProviderBase, IDnsProvider
+    public class DnsProviderTransIP : DnsProviderBase, IDnsProvider, IDisposable
     {
         internal const string BASE_URI = "https://api.transip.nl/v6/";
         internal const string LIST_DOMAINS_URI = BASE_URI + "domains";
@@ -22,7 +22,7 @@ namespace Certify.Providers.DNS.TransIP
         private DnsClient _dnsClient;
         private string _login;
         private string _privateKey;
-        private HttpClient _httpClient;
+        private HttpClient _client;
 
         private int? _customPropagationDelay = null;
         public int PropagationDelaySeconds => _customPropagationDelay != null ? (int)_customPropagationDelay : Definition.PropagationDelaySeconds;
@@ -62,9 +62,8 @@ namespace Certify.Providers.DNS.TransIP
             }
         }
 
-        public DnsProviderTransIP(IHttpClientProvider clientProvider = null)
+        public DnsProviderTransIP()
         {
-            _httpClient = clientProvider?.CreateClient() ?? new HttpClient();
         }
 
         public async Task<ActionResult> Test()
@@ -132,12 +131,13 @@ namespace Certify.Providers.DNS.TransIP
             return await _dnsClient.Remove(root.RootDomain, entry);
         }
 
-        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null)
+        public async Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log = null)
         {
             _log = log;
-
             _login = credentials["login"];
             _privateKey = credentials["privatekey"];
+
+            _client = clientProvider.CreateClient($"Certify/{Definition.Id}");
 
             if (parameters?.ContainsKey("propagationdelay") == true)
             {
@@ -147,8 +147,7 @@ namespace Certify.Providers.DNS.TransIP
                 }
             }
 
-            // Always (re-)initialize DnsClient with the appropriate HttpClient
-            _dnsClient = new DnsClient(_login, _privateKey, PropagationDelaySeconds + 60, _httpClient);
+            _dnsClient = new DnsClient(_login, _privateKey, PropagationDelaySeconds + 60, _client);
 
             return await Task.FromResult(true);
         }
@@ -161,5 +160,9 @@ namespace Certify.Providers.DNS.TransIP
                 name = NormaliseRecordName(root, request.RecordName),
                 type = "TXT"
             };
+        public void Dispose()
+        {
+            _client?.Dispose();
+        }
     }
 }

--- a/src/Certify.Providers/DNS/TransIP/DnsProviderTransIP.cs
+++ b/src/Certify.Providers/DNS/TransIP/DnsProviderTransIP.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,6 +6,7 @@ using Certify.Models.Config;
 using Certify.Models.Plugins;
 using Certify.Models.Providers;
 using Certify.Plugins;
+using System.Net.Http;
 
 namespace Certify.Providers.DNS.TransIP
 {
@@ -21,6 +22,7 @@ namespace Certify.Providers.DNS.TransIP
         private DnsClient _dnsClient;
         private string _login;
         private string _privateKey;
+        private HttpClient _httpClient;
 
         private int? _customPropagationDelay = null;
         public int PropagationDelaySeconds => _customPropagationDelay != null ? (int)_customPropagationDelay : Definition.PropagationDelaySeconds;
@@ -60,8 +62,9 @@ namespace Certify.Providers.DNS.TransIP
             }
         }
 
-        public DnsProviderTransIP()
+        public DnsProviderTransIP(IHttpClientProvider clientProvider = null)
         {
+            _httpClient = clientProvider?.CreateClient() ?? new HttpClient();
         }
 
         public async Task<ActionResult> Test()
@@ -144,7 +147,8 @@ namespace Certify.Providers.DNS.TransIP
                 }
             }
 
-            _dnsClient = new DnsClient(_login, _privateKey, PropagationDelaySeconds + 60);
+            // Always (re-)initialize DnsClient with the appropriate HttpClient
+            _dnsClient = new DnsClient(_login, _privateKey, PropagationDelaySeconds + 60, _httpClient);
 
             return await Task.FromResult(true);
         }

--- a/src/Certify.Server/Certify.Server.Core/Certify.Server.Core/Startup.cs
+++ b/src/Certify.Server/Certify.Server.Core/Certify.Server.Core/Startup.cs
@@ -3,6 +3,8 @@ using System.Security.Claims;
 using Certify.Management;
 using Certify.Models;
 using Certify.Service.Controllers;
+using Certify.Shared.Core.Utils;
+using Certify.Shared.Net;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Negotiate;
 using Microsoft.AspNetCore.DataProtection;
@@ -77,6 +79,9 @@ namespace Certify.Server.Core
 
             ConfigureClaimsTransformation(services);
             Log("Added ClaimsTransformation");
+
+            ConfigureNetworking(services);
+            Log("Added Networking services");
 
             await ConfigureCertifyManager(services);
             Log("Added CertifyManager");
@@ -284,6 +289,38 @@ namespace Certify.Server.Core
             var certifyManager = new Management.CertifyManager();
             await certifyManager.Init();
             services.AddSingleton<Management.ICertifyManager>(certifyManager);
+        }
+
+        private void ConfigureNetworking(IServiceCollection services)
+        {
+            // Register proxy provider as singleton with preferences resolver
+            services.AddSingleton<IProxyProvider>(sp =>
+            {
+                return new ProxyProvider(() =>
+                {
+                    // Read preferences from SettingsManager
+                    try
+                    {
+                        return SettingsManager.ToPreferences() ?? new Certify.Models.Preferences
+                        {
+                            ProxyMode = Certify.Models.ProxyMode.Environment,
+                            ProxyEnabled = true
+                        };
+                    }
+                    catch
+                    {
+                        // Fallback to environment-only proxy
+                        return new Certify.Models.Preferences
+                        {
+                            ProxyMode = Certify.Models.ProxyMode.Environment,
+                            ProxyEnabled = true
+                        };
+                    }
+                });
+            });
+
+            // Register HTTP client provider as singleton
+            services.AddSingleton<Models.Providers.IHttpClientProvider, HttpClientProvider>();
         }
 
         private bool DetermineWindowsAuthRequired()

--- a/src/Certify.Server/Certify.Server.Hub.Api/Startup.cs
+++ b/src/Certify.Server/Certify.Server.Hub.Api/Startup.cs
@@ -7,6 +7,8 @@ using Certify.Server.Hub.Api.Middleware;
 using Certify.Server.Hub.Api.Services;
 using Certify.Server.Hub.Api.SignalR;
 using Certify.Server.Hub.Api.SignalR.ManagementHub;
+using Certify.Shared.Core.Utils;
+using Certify.Shared.Net;
 using Certify.SharedUtils;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.ResponseCompression;
@@ -85,6 +87,22 @@ namespace Certify.Server.Hub.Api
             services.AddOpenApi(); // required in net9 to resolve warning "Unable to find service type 'Microsoft.Extensions.ApiDescriptions.IDocumentProvider' in dependency injection container."
 
             services.AddEndpointsApiExplorer();
+
+            // Register proxy provider and HTTP client provider
+            services.AddSingleton<IProxyProvider>(sp =>
+            {
+                return new ProxyProvider(() =>
+                {
+                    // For Hub API, default to environment proxy since it doesn't have direct access to CoreAppSettings
+                    return new Certify.Models.Preferences
+                    {
+                        ProxyMode = Certify.Models.ProxyMode.Environment,
+                        ProxyEnabled = true
+                    };
+                });
+            });
+
+            services.AddSingleton<Certify.Models.Providers.IHttpClientProvider, HttpClientProvider>();
 
             // Register the Swagger generator, defining 1 or more Swagger documents
             // https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-3.1&tabs=visual-studio

--- a/src/Certify.Server/Certify.Server.HubService/Program.cs
+++ b/src/Certify.Server/Certify.Server.HubService/Program.cs
@@ -251,6 +251,22 @@ var acmeServerState = new AcmeServerConfig(acmeStore, "acme-server");
 builder.Services.AddSingleton<AcmeServerConfig>(acmeServerState);
 builder.Services.AddAcmeServices();
 
+// Register proxy provider and HTTP client provider
+builder.Services.AddSingleton<Certify.Shared.Net.IProxyProvider>(sp =>
+{
+    return new Certify.Shared.Net.ProxyProvider(() =>
+    {
+        // For Hub Service, default to environment proxy
+        return new Certify.Models.Preferences
+        {
+            ProxyMode = Certify.Models.ProxyMode.Environment,
+            ProxyEnabled = true
+        };
+    });
+});
+
+builder.Services.AddSingleton<Certify.Models.Providers.IHttpClientProvider, Certify.Shared.Net.HttpClientProvider>();
+
 // setup public/hub api
 builder.Services.AddSingleton<Certify.Management.ICertifyManager, Certify.Management.CertifyManager>();
 

--- a/src/Certify.Shared.Extensions/Providers/DnsProviderPoshACME.cs
+++ b/src/Certify.Shared.Extensions/Providers/DnsProviderPoshACME.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -1215,7 +1215,7 @@ namespace Certify.Core.Management.Challenges.DNS
                 Id = "DNS01.API.PoshACME.WEDOS",
                 Title = "WEDOS DNS API (using Posh-ACME)",
                 Description = "Validates via DNS API using credentials",
-                HelpUrl = "https://poshac.me/docs/latest/Plugins/WEDOS/",
+                HelpUrl = "https://poshach.me/docs/latest/Plugins/WEDOS/",
                 PropagationDelaySeconds = 600,
                 ProviderParameters =
                 [
@@ -1464,7 +1464,7 @@ namespace Certify.Core.Management.Challenges.DNS
 
         Task<List<DnsZone>> IDnsProvider.GetZones() => Task.FromResult(new List<DnsZone>());
 
-        Task<bool> IDnsProvider.InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log)
+        Task<bool> IDnsProvider.InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, IHttpClientProvider clientProvider, ILog log)
         {
             _log = log;
 

--- a/src/Certify.Shared/Net/HttpClientProvider.cs
+++ b/src/Certify.Shared/Net/HttpClientProvider.cs
@@ -22,17 +22,40 @@ namespace Certify.Shared.Net
             return new HttpClient(CreateHandler());
         }
 
+        public HttpClient CreateClient(string? userAgent = null, bool allowInvalidTls = false)
+        {
+            var client = new HttpClient(CreateHandler(allowInvalidTls));
+
+            if (!string.IsNullOrWhiteSpace(userAgent))
+            {
+                client.DefaultRequestHeaders.Remove("User-Agent");
+                client.DefaultRequestHeaders.Add("User-Agent", userAgent);
+            }
+
+            return client;
+        }
+
         public HttpClient CreateInternalClient()
         {
             return new HttpClient(CreateInternalHandler());
         }
 
-        public HttpMessageHandler CreateHandler()
+        public HttpMessageHandler CreateHandler(bool allowInvalidTls = false)
         {
             var handler = new HttpClientHandler
             {
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
             };
+
+            if (allowInvalidTls)
+            {
+#if NET9_0_OR_GREATER
+                handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+#else
+                handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+                handler.ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true;                
+#endif
+            }
 
             if (_proxyProvider.IsProxyEnabled)
             {

--- a/src/Certify.Shared/Net/HttpClientProvider.cs
+++ b/src/Certify.Shared/Net/HttpClientProvider.cs
@@ -1,0 +1,64 @@
+﻿using System.Net;
+using System.Net.Http;
+using Certify.Models.Providers;
+using Certify.Shared.Core.Utils;
+
+namespace Certify.Shared.Net
+{
+    /// <summary>
+    /// Default implementation of IHttpClientProvider
+    /// </summary>
+    public class HttpClientProvider : IHttpClientProvider
+    {
+        private readonly IProxyProvider _proxyProvider;
+
+        public HttpClientProvider(IProxyProvider proxyProvider)
+        {
+            _proxyProvider = proxyProvider;
+        }
+
+        public HttpClient CreateClient()
+        {
+            return new HttpClient(CreateHandler());
+        }
+
+        public HttpClient CreateInternalClient()
+        {
+            return new HttpClient(CreateInternalHandler());
+        }
+
+        public HttpMessageHandler CreateHandler()
+        {
+            var handler = new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            };
+
+            if (_proxyProvider.IsProxyEnabled)
+            {
+                var proxy = _proxyProvider.GetProxy();
+                if (proxy != null)
+                {
+                    handler.UseProxy = true;
+                    handler.Proxy = proxy;
+
+                    if (proxy.Credentials != null)
+                    {
+                        handler.DefaultProxyCredentials = proxy.Credentials;
+                    }
+                }
+            }
+
+            return handler;
+        }
+
+        public HttpMessageHandler CreateInternalHandler()
+        {
+            return new HttpClientHandler
+            {
+                UseProxy = false,
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            };
+        }
+    }
+}

--- a/src/Certify.Shared/Net/IProxyProvider.cs
+++ b/src/Certify.Shared/Net/IProxyProvider.cs
@@ -1,0 +1,21 @@
+﻿using System.Net;
+
+namespace Certify.Shared.Net
+{
+    /// <summary>
+    /// Provides proxy configuration for outbound HTTP requests
+    /// </summary>
+    public interface IProxyProvider
+    {
+        /// <summary>
+        /// Get the configured proxy, or null if no proxy should be used
+        /// </summary>
+        /// <returns>IWebProxy instance or null</returns>
+        IWebProxy GetProxy();
+
+        /// <summary>
+        /// Check if proxy is currently enabled
+        /// </summary>
+        bool IsProxyEnabled { get; }
+    }
+}

--- a/src/Certify.Shared/Net/ProxyHelper.cs
+++ b/src/Certify.Shared/Net/ProxyHelper.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+
+namespace Certify.Shared.Net
+{
+    /// <summary>
+    /// Provides simple proxy application from environment variables for outbound HTTP.
+    /// Does not touch service-to-service HttpClient factory registrations.
+    /// </summary>
+    public static class ProxyHelper
+    {
+        public static IWebProxy GetProxyFromEnvironment()
+        {
+
+            var certifyProxy = Environment.GetEnvironmentVariable("CERTIFY_PROXY") ?? Environment.GetEnvironmentVariable("certify_proxy");
+
+            var httpsProxy = Environment.GetEnvironmentVariable("HTTPS_PROXY") ?? Environment.GetEnvironmentVariable("https_proxy");
+
+            var httpProxy = Environment.GetEnvironmentVariable("HTTP_PROXY") ?? Environment.GetEnvironmentVariable("http_proxy");
+
+            var noProxy = Environment.GetEnvironmentVariable("NO_PROXY") ?? Environment.GetEnvironmentVariable("no_proxy");
+
+            var proxyUrl = certifyProxy ?? httpsProxy ?? httpProxy;
+
+            if (string.IsNullOrWhiteSpace(proxyUrl))
+            {
+                return null;
+            }
+
+            try
+            {
+                var uri = new Uri(proxyUrl);
+                var webProxy = new WebProxy(uri)
+                {
+                    BypassProxyOnLocal = true
+                };
+
+                if (!string.IsNullOrWhiteSpace(noProxy))
+                {
+                    var list = noProxy.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+                    if (list != null && list.Any())
+                    {
+                        webProxy.BypassList = list.ToArray();
+                    }
+                }
+
+                return webProxy;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static void ApplyProxyIfConfigured(HttpMessageHandler handler)
+        {
+            var proxy = GetProxyFromEnvironment();
+            if (proxy == null)
+            {
+                return;
+            }
+
+            var http = handler as HttpClientHandler;
+            if (http != null)
+            {
+                http.UseProxy = true;
+                http.Proxy = proxy;
+            }
+        }
+
+        /// <summary>
+        /// Apply proxy from an IProxyProvider to an HttpMessageHandler
+        /// </summary>
+        public static void ApplyProxy(HttpMessageHandler handler, IProxyProvider proxyProvider)
+        {
+            if (proxyProvider == null || !proxyProvider.IsProxyEnabled)
+            {
+                return;
+            }
+
+            var proxy = proxyProvider.GetProxy();
+            if (proxy == null)
+            {
+                return;
+            }
+
+            var http = handler as HttpClientHandler;
+            if (http != null)
+            {
+                http.UseProxy = true;
+                http.Proxy = proxy;
+
+                if (proxy.Credentials != null)
+                {
+                    http.DefaultProxyCredentials = proxy.Credentials;
+                }
+            }
+        }
+    }
+}

--- a/src/Certify.Shared/Net/ProxyProvider.cs
+++ b/src/Certify.Shared/Net/ProxyProvider.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using Certify.Models;
+
+namespace Certify.Shared.Net
+{
+    /// <summary>
+    /// Default implementation of IProxyProvider that reads from Preferences and environment
+    /// </summary>
+    public class ProxyProvider : IProxyProvider
+    {
+        private readonly Func<Preferences> _getPreferences;
+
+        /// <summary>
+        /// Create a proxy provider with a function to get preferences
+        /// </summary>
+        /// <param name="getPreferences">Function to retrieve current proxy preferences</param>
+        public ProxyProvider(Func<Preferences> getPreferences = null)
+        {
+            _getPreferences = getPreferences ?? (() => new Preferences { ProxyMode = ProxyMode.Environment, ProxyEnabled = true });
+        }
+
+        public bool IsProxyEnabled
+        {
+            get
+            {
+                var prefs = _getPreferences();
+                return prefs?.ProxyEnabled == true && prefs.ProxyMode != ProxyMode.None;
+            }
+        }
+
+        public IWebProxy GetProxy()
+        {
+            var prefs = _getPreferences();
+            if (prefs == null || !prefs.ProxyEnabled || prefs.ProxyMode == ProxyMode.None)
+            {
+                return null;
+            }
+
+            IWebProxy proxy = null;
+
+            switch (prefs.ProxyMode)
+            {
+                case ProxyMode.System:
+                    proxy = WebRequest.DefaultWebProxy;
+                    break;
+
+                case ProxyMode.Environment:
+                    proxy = ProxyHelper.GetProxyFromEnvironment();
+                    break;
+
+                case ProxyMode.Custom:
+                    if (!string.IsNullOrWhiteSpace(prefs.ProxyUri))
+                    {
+                        try
+                        {
+                            var uri = new Uri(prefs.ProxyUri);
+                            var webProxy = new WebProxy(uri)
+                            {
+                                BypassProxyOnLocal = prefs.ProxyBypassOnLocal
+                            };
+
+                            if (!string.IsNullOrWhiteSpace(prefs.ProxyBypassList))
+                            {
+                                var bypassList = prefs.ProxyBypassList
+                                .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
+                                     .Select(s => s.Trim())
+                                         .Where(s => !string.IsNullOrEmpty(s))
+                                    .ToArray();
+
+                                if (bypassList.Length > 0)
+                                {
+                                    webProxy.BypassList = bypassList.ToArray();
+                                }
+                            }
+
+                            proxy = webProxy;
+                        }
+                        catch
+                        {
+                            // Invalid proxy URI, return null
+                            return null;
+                        }
+                    }
+
+                    break;
+            }
+
+            if (proxy != null)
+            {
+                // Apply credentials if configured
+                if (prefs.ProxyUseDefaultCredentials)
+                {
+                    proxy.Credentials = CredentialCache.DefaultNetworkCredentials;
+                }
+
+                // Note: Credentials from StoredCredential would need to be loaded async
+                // For now, proxy auth via credentials requires DefaultNetworkCredentials
+                // TODO: Add support for custom credentials from StoredCredential
+            }
+
+            return proxy;
+        }
+    }
+}

--- a/src/Certify.Tests/Certify.Core.Tests.Integration/DNS/DnsAPITest.AWSRoute53.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Integration/DNS/DnsAPITest.AWSRoute53.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Certify.Datastore.SQLite;
 using Certify.Models.Providers;
+using Certify.Shared.Net;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Certify.Core.Tests.DNS
@@ -51,7 +52,7 @@ namespace Certify.Core.Tests.DNS
             _credentials = await credentialsManager.GetUnlockedCredentialsDictionary(_credStorageKey);
 
             _provider = new Providers.DNS.AWSRoute53.DnsProviderAWSRoute53();
-            await _provider.InitProvider(_credentials, new Dictionary<string, string> { });
+            await _provider.InitProvider(_credentials, [], new HttpClientProvider(new ProxyProvider()));
         }
 
         [TestMethod, TestCategory("DNS")]

--- a/src/Certify.Tests/Certify.Core.Tests.Integration/DNS/DnsAPITest.Azure.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Integration/DNS/DnsAPITest.Azure.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Certify.Datastore.SQLite;
 using Certify.Models.Providers;
+using Certify.Shared.Net;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Certify.Core.Tests.DNS
@@ -52,7 +53,7 @@ namespace Certify.Core.Tests.DNS
             _credentials = await credentialsManager.GetUnlockedCredentialsDictionary(_credStorageKey);
 
             _provider = new Providers.DNS.Azure.DnsProviderAzure();
-            await _provider.InitProvider(_credentials, new Dictionary<string, string> { });
+            await _provider.InitProvider(_credentials, [], new HttpClientProvider(new ProxyProvider()));
         }
 
         [TestMethod, TestCategory("DNS")]

--- a/src/Certify.Tests/Certify.Core.Tests.Integration/DNS/DnsAPITest.Cloudflare.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Integration/DNS/DnsAPITest.Cloudflare.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Certify.Datastore.SQLite;
 using Certify.Models.Providers;
+using Certify.Shared.Net;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Certify.Core.Tests.DNS
@@ -51,7 +52,7 @@ namespace Certify.Core.Tests.DNS
             _credentials = await credentialsManager.GetUnlockedCredentialsDictionary(_credStorageKey);
 
             _provider = new Providers.DNS.Cloudflare.DnsProviderCloudflare();
-            await _provider.InitProvider(_credentials, new Dictionary<string, string> { });
+            await _provider.InitProvider(_credentials, [], new HttpClientProvider(new ProxyProvider()));
         }
 
         [TestMethod, TestCategory("DNS")]


### PR DESCRIPTION
Implements proxy configuration for outbound HTTP requests in DNS providers.

This change introduces proxy support, allowing users to configure a proxy server for DNS resolution. This enhances security and enables the application to function in environments where direct internet access is restricted.

- Introduces `IHttpClientProvider` and `HttpClientProvider` for managing `HttpClient` instances with proxy configurations.
- Adds `ProxyMode` and related properties to `Preferences` for proxy settings.
- Modifies DNS provider implementations to use `IHttpClientProvider` for creating `HttpClient` instances.