### PR TITLE
Honor selected CA for internal hostname validation

### DIFF
--- a/src/Certify.Core/Management/CertifyManager/CertifyManager.ManagedCertificates.cs
+++ b/src/Certify.Core/Management/CertifyManager/CertifyManager.ManagedCertificates.cs
@@ -679,11 +679,15 @@ namespace Certify.Management
                 }
             }
 
+            var currentCAId = GetCurrentCAId(managedCertificate);
+            _certificateAuthorities.TryGetValue(currentCAId, out var preferredCA);
+
             results.AddRange(
                 await _challengeResponseService.TestChallengeResponse(
                     log,
                     serverProvider,
                     managedCertificate,
+                    preferredCA,
                     isPreviewMode,
                     CoreAppSettings.Current.EnableDNSValidationChecks,
                     performCleanupOnly: false,
@@ -728,12 +732,15 @@ namespace Certify.Management
             var results = new List<StatusMessage>();
 
             var serverProvider = GetTargetServerProvider(managedCertificate);
+            var currentCAId = GetCurrentCAId(managedCertificate);
+            _certificateAuthorities.TryGetValue(currentCAId, out var preferredCA);
 
             results.AddRange(
                await _challengeResponseService.TestChallengeResponse(
                    log,
                    serverProvider,
                    managedCertificate,
+                   preferredCA,
                    isPreviewMode: false,
                    enableDnsChecks: false,
                    performCleanupOnly: true,
@@ -1165,4 +1172,3 @@ namespace Certify.Management
         }
     }
 }
-

--- a/src/Certify.Core/Management/Challenges/ChallengeResponseService.cs
+++ b/src/Certify.Core/Management/Challenges/ChallengeResponseService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Certify.Management;
+using Certify.Models.CertificateAuthorities;
 using Certify.Models;
 using Certify.Models.Config;
 using Certify.Models.Providers;
@@ -43,6 +44,7 @@ namespace Certify.Core.Management.Challenges
             ILog log,
             ITargetWebServer serverManager,
             ManagedCertificate managedCertificate,
+            CertificateAuthority preferredCA,
             bool isPreviewMode,
             bool enableDnsChecks,
             bool performCleanupOnly,
@@ -56,7 +58,7 @@ namespace Certify.Core.Management.Challenges
 
             if (!performCleanupOnly)
             {
-                var validationResult = CertificateEditorService.Validate(managedCertificate, null, null, false);
+                var validationResult = CertificateEditorService.Validate(managedCertificate, null, preferredCA, false);
 
                 if (!validationResult.IsValid)
                 {


### PR DESCRIPTION
Internal hostnames were being rejected during challenge testing even when the managed certificate was configured to use a CA that allows them. The validation path did not receive the currently applicable CA, so it defaulted to rejecting internal names.

## What changed
- Resolve the managed certificate's active CA before challenge testing and cleanup.
- Pass that CA into `ChallengeResponseService.TestChallengeResponse(...)`.
- Use the passed CA in `CertificateEditorService.Validate(...)` so `AllowInternalHostnames` is evaluated against the selected CA.

This keeps challenge-test validation aligned with per-certificate/per-instance CA selection instead of a null/default CA context.

Fixes: #745